### PR TITLE
Add scaffolding to allow Adapter to process messages

### DIFF
--- a/src/publisher/pythd/adapter.rs
+++ b/src/publisher/pythd/adapter.rs
@@ -73,20 +73,22 @@ impl Adapter {
         }
     }
 
-    pub async fn run(&mut self) -> Result<()> {
+    pub async fn run(&mut self) {
         loop {
             tokio::select! {
                 Some(message) = self.message_rx.recv() => {
-                    self.handle_message(message).await
+                    if let Err(err) = self.handle_message(message).await {
+                        error!(self.logger, "{:#}", err; "error" => format!("{:?}", err))
+                    }
                 }
                 _ = self.shutdown_rx.recv() => {
                     info!(self.logger, "shutdown signal received");
-                    return Ok(());
+                    return;
                 }
                 _ = self.notify_price_sched_interval.tick() => {
                     todo!()
                 }
-            }?;
+            };
         }
     }
 


### PR DESCRIPTION
This PR adds boilerplate scaffolding to allow the Pythd adapter to process messages sent to it from the websocket API.

Tests will be added with the implementation of each message handler.