### PR TITLE
Add notify_price_sched handler to Adapter

### DIFF
--- a/src/publisher/pythd/adapter.rs
+++ b/src/publisher/pythd/adapter.rs
@@ -243,7 +243,6 @@ mod tests {
             .unwrap();
 
         let subscription_id = result_rx.await.unwrap().unwrap();
-        assert_eq!(subscription_id, 1);
 
         // Expect that we recieve several Notify Price Sched notifications
         for _ in 0..10 {


### PR DESCRIPTION
Add functionality to the adapter to send `notify_price_sched` messages at a fixed interval.