### PR TITLE
Derive Ord, PartialOrd for pythd API structures

### DIFF
--- a/src/publisher/pythd/api.rs
+++ b/src/publisher/pythd/api.rs
@@ -16,28 +16,28 @@ pub type Exponent = i64;
 pub type Conf = u64;
 pub type Slot = u64;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
 pub struct ProductAccountMetadata {
     pub account: Pubkey,
     pub attr_dict: Attrs,
     pub prices: Vec<PriceAccountMetadata>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
 pub struct PriceAccountMetadata {
     pub account: Pubkey,
     pub price_type: String,
     pub price_exponent: Exponent,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
 pub struct ProductAccount {
     pub account: Pubkey,
     pub attr_dict: Attrs,
     pub price_accounts: Vec<PriceAccount>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
 pub struct PriceAccount {
     pub account: Pubkey,
     pub price_type: String,
@@ -55,7 +55,7 @@ pub struct PriceAccount {
     pub publisher_accounts: Vec<PublisherAccount>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
 pub struct PublisherAccount {
     pub account: Pubkey,
     pub status: String,
@@ -64,20 +64,20 @@ pub struct PublisherAccount {
     pub slot: Slot,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
 pub struct NotifyPrice {
     pub subscription: SubscriptionID,
     pub result: PriceUpdate,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
 pub struct NotifyPriceSched {
     pub subscription: SubscriptionID,
 }
 
 pub type SubscriptionID = i64;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
 pub struct PriceUpdate {
     pub price: Price,
     pub conf: Conf,


### PR DESCRIPTION
These are helpful as they allow sorting the data structures in tests.