### PR TITLE
Notify global store when accounts change

### DIFF
--- a/src/publisher/solana/oracle.rs
+++ b/src/publisher/solana/oracle.rs
@@ -83,6 +83,7 @@ impl Oracle {
     pub fn new(
         config: Config,
         updates_rx: mpsc::Receiver<(Pubkey, solana_sdk::account::Account)>,
+        global_store_tx: mpsc::Sender<global::Update>,
         logger: Logger,
     ) -> Self {
         let rpc_client = RpcClient::new_with_commitment(
@@ -99,6 +100,7 @@ impl Oracle {
             rpc_client,
             poll_interval,
             updates_rx,
+            global_store_tx,
             logger,
         }
     }


### PR DESCRIPTION
This PR establishes the link between the Oracle RPC client and the global store (the internal view of the on-chain data). We notify the global store:

- When we do a poll. We send all the data and the global store filters out accounts that have not changed.
- When an account we are subscribed to changes.