### PR TITLE
Configure logging level using RUST_LOG environment variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7"
 
 [[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2399,6 +2405,7 @@ dependencies = [
  "serde_json",
  "slog",
  "slog-async",
+ "slog-envlogger",
  "slog-extlog",
  "slog-term",
  "soketto",
@@ -3176,6 +3183,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "slog-envlogger"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "906a1a0bc43fed692df4b82a5e2fbfc3733db8dad8bb514ab27a4f23ad04f5c0"
+dependencies = [
+ "log",
+ "regex",
+ "slog",
+ "slog-async",
+ "slog-scope",
+ "slog-stdlog",
+ "slog-term",
+]
+
+[[package]]
 name = "slog-extlog"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3199,6 +3221,28 @@ dependencies = [
  "serde_json",
  "slog",
  "time 0.3.14",
+]
+
+[[package]]
+name = "slog-scope"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f95a4b4c3274cd2869549da82b57ccc930859bdbf5bcea0424bc5f140b3c786"
+dependencies = [
+ "arc-swap",
+ "lazy_static",
+ "slog",
+]
+
+[[package]]
+name = "slog-stdlog"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6706b2ace5bbae7291d3f8d2473e2bfab073ccd7d03670946197aec98471fa3e"
+dependencies = [
+ "log",
+ "slog",
+ "slog-scope",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ thiserror = "1.0.32"
 solana-shadow = "0.2.4"
 clap = { version = "4.0.32", features = ["derive"] }
 humantime-serde = "1.1.1"
+slog-envlogger = "2.2.0"
 
 [dev-dependencies]
 tokio-util = { version = "0.7.0", features = ["full"] }

--- a/integration-tests/tests/test_integration.py
+++ b/integration-tests/tests/test_integration.py
@@ -307,6 +307,7 @@ class PythTest:
         LOGGER.debug("Launching agent logging to %s", log_dir)
 
         os.environ["RUST_BACKTRACE"] = "full"
+        os.environ["RUST_LOG"] = "debug"
         with self.spawn("../target/release/agent --config agent_conf.toml", log_dir=log_dir):
             time.sleep(3)
             yield

--- a/src/bin/agent.rs
+++ b/src/bin/agent.rs
@@ -11,7 +11,11 @@ use {
         Drain,
         Logger,
     },
-    std::path::PathBuf,
+    slog_envlogger::LogBuilder,
+    std::{
+        env,
+        path::PathBuf,
+    },
 };
 
 #[derive(Parser, Debug)]
@@ -26,12 +30,15 @@ struct Arguments {
 #[tokio::main]
 async fn main() {
     let logger = slog::Logger::root(
-        slog_async::Async::new(
-            slog_term::CompactFormat::new(slog_term::TermDecorator::new().build())
-                .build()
-                .fuse(),
+        slog_async::Async::default(
+            LogBuilder::new(
+                slog_term::CompactFormat::new(slog_term::TermDecorator::new().stdout().build())
+                    .build()
+                    .fuse(),
+            )
+            .parse(&env::var("RUST_LOG").unwrap_or("info".to_string()))
+            .build(),
         )
-        .build()
         .fuse(),
         o!(),
     );


### PR DESCRIPTION
This PR introduces [slog_envlogger](https://docs.rs/slog-envlogger/latest/slog_envlogger/), which allows the log level to be controlled at runtime by the `RUST_LOG` environment variable using [env_logger](https://docs.rs/env_logger/latest/env_logger/)'s flexible filtering system.