### PR TITLE
Parallelize fetching product and price account data

### DIFF
--- a/src/agent/solana/oracle.rs
+++ b/src/agent/solana/oracle.rs
@@ -111,7 +111,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             commitment:               CommitmentLevel::Confirmed,
-            poll_interval_duration:   Duration::from_secs(5 * 60),
+            poll_interval_duration:   Duration::from_secs(2 * 60),
             subscriber_enabled:       true,
             updates_channel_capacity: 10000,
             data_channel_capacity:    10000,


### PR DESCRIPTION
This PR fetches all product and price accounts in parallel, reducing the initialization time from a few minutes to a few seconds.