### PR TITLE
Improve cargo build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2384,7 +2384,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [[bin]]
@@ -27,7 +27,7 @@ pyth-sdk-solana = "0.6.0"
 solana-client = "1.10.24"
 solana-sdk = "1.10.24"
 bincode = "1.3.3"
-slog = "2.7.0"
+slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_warn"] }
 slog-term = "2.9.0"
 rand = "0.8.5"
 slog-async = "2.7.0"
@@ -47,3 +47,9 @@ rand = "0.8.5"
 tokio-retry = "0.3.0"
 slog-extlog = "8.0.0"
 iobuffer = "0.2.0"
+
+[profile.release]
+panic = 'abort'
+
+[profile.dev]
+panic = 'abort'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ pyth-sdk-solana = "0.6.0"
 solana-client = "1.10.24"
 solana-sdk = "1.10.24"
 bincode = "1.3.3"
-slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_warn"] }
+slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_trace"] }
 slog-term = "2.9.0"
 rand = "0.8.5"
 slog-async = "2.7.0"


### PR DESCRIPTION
This change will:
- Enable trace/debug logs in release build
- Abort the whole process on a thread panic because there is no way to handle them in the code. The agent usually handles all the errors and never panics 