### PR TITLE
Request compute units per price update instruction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2384,7 +2384,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [[bin]]

--- a/config/config.toml
+++ b/config/config.toml
@@ -41,7 +41,7 @@ key_store.root_path = "/path/to/keystore"
 # Maximum size of a batch
 # exporter.max_batch_size = 12
 
-# Maximum number of compute units requested by each update_price transaction
+# Number of compute units requested per update_price instruction within the transaction.
 # exporter.compute_unit_limit = 20000
 
 # Price per compute unit offered for update_price transactions

--- a/src/agent/solana/exporter.rs
+++ b/src/agent/solana/exporter.rs
@@ -335,7 +335,6 @@ impl Exporter {
             .collect::<Vec<_>>();
 
         let network_state = *self.network_state_rx.borrow();
-        let refreshed_batch_size = refreshed_batch.len() as u32;
         for (identifier, price_info_result) in refreshed_batch {
             let price_info = price_info_result?;
 
@@ -386,7 +385,7 @@ impl Exporter {
 
         // Pay priority fees, if configured
         instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(
-            self.config.compute_unit_limit * refreshed_batch_size,
+            self.config.compute_unit_limit * instructions.len() as u32,
         ));
         if let Some(compute_unit_price_micro_lamports) =
             self.config.compute_unit_price_micro_lamports

--- a/src/agent/solana/exporter.rs
+++ b/src/agent/solana/exporter.rs
@@ -333,6 +333,7 @@ impl Exporter {
             .collect::<Vec<_>>();
 
         let network_state = *self.network_state_rx.borrow();
+        let refreshed_batch_size = refreshed_batch.len() as u32;
         for (identifier, price_info_result) in refreshed_batch {
             let price_info = price_info_result?;
 
@@ -383,7 +384,7 @@ impl Exporter {
 
         // Pay priority fees, if configured
         instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(
-            self.config.compute_unit_limit,
+            self.config.compute_unit_limit * refreshed_batch_size,
         ));
         if let Some(compute_unit_price_micro_lamports) =
             self.config.compute_unit_price_micro_lamports

--- a/src/agent/solana/exporter.rs
+++ b/src/agent/solana/exporter.rs
@@ -103,7 +103,9 @@ pub struct Config {
     pub inflight_transactions_channel_capacity:  usize,
     /// Configuration for the Transaction Monitor
     pub transaction_monitor:                     transaction_monitor::Config,
-    /// Maximum number of compute units requested by each update_price transaction
+    /// Number of compute units requested per update_price instruction within the transaction
+    /// (i.e., requested units equals `n * compute_unit_limit`, where `n` is the number of update_price
+    /// instructions)
     pub compute_unit_limit:                      u32,
     /// Price per compute unit offered for update_price transactions
     pub compute_unit_price_micro_lamports:       Option<u64>,


### PR DESCRIPTION
The new pyth agent seems to request 20k CUs for the entire transaction 

https://explorer.solana.com/tx/5zzK9k3pBrL7aH4jMrSrYLjT5AnqbRqu4aE5gK7ozF3MRCzdhhCrcXZu3Fdzo5uUiYF3YdrVAoVfvkJK29rrzuMU

but the old agent seems to request 20k CUs per price update instruction in the transaction:

https://explorer.solana.com/tx/4ASipr9GayTsejvRxLneWiMaZXdbwASo6iGtTYLM3pwwMU1u7X1HZ94K9Lvs2ntNQn45zt1EZ6V9xANwRfyx7kYJ

This explains why the new pyth-agent is running out of compute on mainnet. This PR changes it to request cus per instruction.