### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2384,7 +2384,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "0.1.3"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "0.1.3"
+version = "1.0.0"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
As we are starting to roll this out for production the version should become 1.0.0 to indicate that it is a production-ready code.