### PR TITLE
Add a dashboard in a new metrics.rs module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2679,6 +2679,7 @@ dependencies = [
  "clap 4.0.32",
  "config",
  "futures-util",
+ "humantime",
  "humantime-serde",
  "iobuffer",
  "jrpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,27 +2669,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
-dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
- "memchr",
- "parking_lot",
- "protobuf",
- "thiserror",
-]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
-
-[[package]]
 name = "pyth-agent"
 version = "1.0.0"
 dependencies = [
@@ -2703,10 +2682,8 @@ dependencies = [
  "humantime-serde",
  "iobuffer",
  "jrpc",
- "lazy_static",
  "parking_lot",
  "portpicker",
- "prometheus",
  "pyth-sdk",
  "pyth-sdk-solana",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -36,7 +36,7 @@ dependencies = [
  "cfg-if",
  "cipher 0.3.0",
  "cpufeatures",
- "opaque-debug",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -127,9 +127,24 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
+name = "ascii-canvas"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff8eb72df928aafb99fe5d37b383f2fe25bd2a765e3e5f7c365916b6f2463a29"
+dependencies = [
+ "term 0.5.2",
+]
 
 [[package]]
 name = "asn1-rs"
@@ -223,6 +238,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
+dependencies = [
+ "autocfg 1.1.0",
+]
+
+[[package]]
+name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
@@ -255,6 +279,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,13 +309,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2b_simd"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.2",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "blake3"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.7.2",
  "cc",
  "cfg-if",
  "constant_time_eq",
@@ -285,12 +335,24 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding 0.1.5",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
- "generic-array",
+ "block-padding 0.2.1",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -299,7 +361,16 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.6",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
 ]
 
 [[package]]
@@ -407,6 +478,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+
+[[package]]
 name = "bytemuck"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,7 +562,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -534,7 +611,7 @@ version = "4.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2 1.0.43",
  "quote 1.0.21",
@@ -548,6 +625,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -676,7 +762,7 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "cfg-if",
  "crossbeam-utils",
  "memoffset",
@@ -706,7 +792,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.6",
  "typenum",
 ]
 
@@ -716,7 +802,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.6",
  "subtle",
 ]
 
@@ -803,12 +889,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array 0.12.4",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -820,6 +921,17 @@ dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+dependencies = [
+ "libc",
+ "redox_users 0.3.5",
+ "winapi",
 ]
 
 [[package]]
@@ -839,7 +951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.3",
  "winapi",
 ]
 
@@ -882,6 +994,18 @@ name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+
+[[package]]
+name = "docopt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f3f119846c823f9eafcf953a8f6ffb6ed69bf6240883261a7f13b634579a51f"
+dependencies = [
+ "lazy_static",
+ "regex",
+ "serde",
+ "strsim 0.10.0",
+]
 
 [[package]]
 name = "dyn-clone"
@@ -929,6 +1053,15 @@ name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "ena"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8944dc8fa28ce4a38f778bd46bf7d923fe73eed5a439398507246c8e017e6f36"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -1027,6 +1160,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1179,12 @@ name = "feature-probe"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
+
+[[package]]
+name = "fixedbitset"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 
 [[package]]
 name = "flate2"
@@ -1081,6 +1226,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -1178,6 +1329,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -1289,6 +1449,15 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
@@ -1352,9 +1521,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
  "digest 0.9.0",
- "generic-array",
+ "generic-array 0.14.6",
  "hmac 0.8.1",
 ]
+
+[[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
 name = "http"
@@ -1503,7 +1678,7 @@ version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "hashbrown 0.12.3",
 ]
 
@@ -1525,7 +1700,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -1569,6 +1744,15 @@ dependencies = [
  "io-lifetimes",
  "rustix",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1647,6 +1831,43 @@ name = "keccak"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
+
+[[package]]
+name = "lalrpop"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64dc3698e75d452867d9bd86f4a723f452ce9d01fe1d55990b79f0c790aa67db"
+dependencies = [
+ "ascii-canvas",
+ "atty",
+ "bit-set",
+ "diff",
+ "docopt",
+ "ena",
+ "itertools 0.8.2",
+ "lalrpop-util",
+ "petgraph",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "sha2 0.8.2",
+ "string_cache",
+ "term 0.5.2",
+ "unicode-xid 0.1.0",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c277d18683b36349ab5cd030158b54856fca6bb2d5dc5263b06288f486958b7c"
+
+[[package]]
+name = "language-tags"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 
 [[package]]
 name = "lazy_static"
@@ -1736,7 +1957,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "scopeguard",
 ]
 
@@ -1785,7 +2006,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -1880,6 +2101,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
 name = "nix"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1922,7 +2149,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits",
 ]
@@ -1933,7 +2160,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits",
 ]
@@ -1944,7 +2171,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-traits",
 ]
 
@@ -1965,7 +2192,7 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-traits",
 ]
 
@@ -1975,7 +2202,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits",
 ]
@@ -1986,7 +2213,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-bigint 0.2.6",
  "num-integer",
  "num-traits",
@@ -1998,7 +2225,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -2064,6 +2291,12 @@ checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
 name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
@@ -2106,7 +2339,7 @@ version = "0.9.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "cc",
  "libc",
  "pkg-config",
@@ -2122,6 +2355,12 @@ dependencies = [
  "dlv-list",
  "hashbrown 0.12.3",
 ]
+
+[[package]]
+name = "ordermap"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
 
 [[package]]
 name = "os_str_bytes"
@@ -2147,7 +2386,7 @@ checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.36.1",
 ]
@@ -2245,6 +2484,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
+dependencies = [
+ "fixedbitset",
+ "ordermap",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
+dependencies = [
+ "phf_shared",
+ "rand 0.6.5",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,7 +2569,7 @@ checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "opaque-debug",
+ "opaque-debug 0.3.0",
  "universal-hash",
 ]
 
@@ -2319,6 +2587,12 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro-crate"
@@ -2365,6 +2639,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
+
+[[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2383,6 +2669,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
 name = "pyth-agent"
 version = "1.0.0"
 dependencies = [
@@ -2396,8 +2703,10 @@ dependencies = [
  "humantime-serde",
  "iobuffer",
  "jrpc",
+ "lazy_static",
  "parking_lot",
  "portpicker",
+ "prometheus",
  "pyth-sdk",
  "pyth-sdk-solana",
  "rand 0.8.5",
@@ -2419,6 +2728,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "typed-html",
  "warp",
 ]
 
@@ -2540,6 +2850,25 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.8",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc 0.1.0",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg",
+ "rand_xorshift",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -2548,7 +2877,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc",
+ "rand_hc 0.2.0",
 ]
 
 [[package]]
@@ -2560,6 +2889,16 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2584,6 +2923,21 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -2602,11 +2956,73 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2624,7 +3040,7 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -2655,6 +3071,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2665,12 +3096,23 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+dependencies = [
+ "getrandom 0.1.16",
+ "redox_syscall 0.1.57",
+ "rust-argon2",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom 0.2.7",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
@@ -2777,6 +3219,18 @@ dependencies = [
  "serde",
  "serde_json",
  "winapi",
+]
+
+[[package]]
+name = "rust-argon2"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
+dependencies = [
+ "base64 0.13.0",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -3066,7 +3520,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
- "opaque-debug",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -3093,6 +3547,18 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
@@ -3101,7 +3567,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
- "opaque-debug",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -3124,7 +3590,7 @@ dependencies = [
  "block-buffer 0.9.0",
  "digest 0.9.0",
  "keccak",
- "opaque-debug",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -3153,6 +3619,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0ea32af43239f0d353a7dd75a22d94c329c8cdaafdcb4c1c1335aa10c298a4a"
 
 [[package]]
+name = "siphasher"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
+
+[[package]]
 name = "sized-chunks"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3168,7 +3640,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -3263,7 +3735,7 @@ checksum = "87d29185c55b7b258b4f120eab00f48557d4d9bc814f41713f449d35b0f8977c"
 dependencies = [
  "atty",
  "slog",
- "term",
+ "term 0.7.0",
  "thread_local",
  "time 0.3.14",
 ]
@@ -3376,7 +3848,7 @@ dependencies = [
  "futures-util",
  "indexmap",
  "indicatif",
- "itertools",
+ "itertools 0.10.3",
  "jsonrpc-core",
  "lazy_static",
  "log",
@@ -3458,7 +3930,7 @@ checksum = "95185172953a206d2aae8e4448d8f295c9b6e3304c43efded5192d3cc5b99d04"
 dependencies = [
  "bs58",
  "bv",
- "generic-array",
+ "generic-array 0.14.6",
  "im",
  "lazy_static",
  "log",
@@ -3587,7 +4059,7 @@ dependencies = [
  "console_log",
  "curve25519-dalek",
  "getrandom 0.1.16",
- "itertools",
+ "itertools 0.10.3",
  "js-sys",
  "lazy_static",
  "libsecp256k1",
@@ -3619,7 +4091,7 @@ dependencies = [
  "base64 0.13.0",
  "bincode",
  "enum-iterator",
- "itertools",
+ "itertools 0.10.3",
  "libc",
  "libloading",
  "log",
@@ -3682,9 +4154,9 @@ dependencies = [
  "digest 0.10.3",
  "ed25519-dalek",
  "ed25519-dalek-bip32",
- "generic-array",
+ "generic-array 0.14.6",
  "hmac 0.12.1",
- "itertools",
+ "itertools 0.10.3",
  "js-sys",
  "lazy_static",
  "libsecp256k1",
@@ -3761,7 +4233,7 @@ dependencies = [
  "futures-util",
  "histogram",
  "indexmap",
- "itertools",
+ "itertools 0.10.3",
  "libc",
  "log",
  "nix",
@@ -3956,6 +4428,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8207e78455ffdf55661170876f88daf85356e4edd54e0a3dbc79586ca1e50cbe"
 
 [[package]]
+name = "string_cache"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89c058a82f9fd69b1becf8c274f412281038877c553182f1d02eb027045a2d67"
+dependencies = [
+ "lazy_static",
+ "new_debug_unreachable",
+ "phf_shared",
+ "precomputed-hash",
+ "serde",
+ "string_cache_codegen",
+ "string_cache_shared",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f45ed1b65bf9a4bf2f7b7dc59212d1926e9eaf00fa998988e420fd124467c6"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "string_cache_shared",
+]
+
+[[package]]
+name = "string_cache_shared"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1884d1bc09741d466d9b14e6d37ac89d6909cbcac41dd9ae982d4d063bbedfc"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3966,6 +4472,24 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bd81eb48f4c437cadc685403cad539345bf703d78e63707418431cecd4522b"
+
+[[package]]
+name = "strum_macros"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
+]
 
 [[package]]
 name = "subtle"
@@ -4022,8 +4546,19 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
+name = "term"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
+dependencies = [
+ "byteorder",
+ "dirs",
  "winapi",
 ]
 
@@ -4164,7 +4699,7 @@ version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "bytes",
  "libc",
  "memchr",
@@ -4397,6 +4932,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-html"
+version = "0.2.2"
+source = "git+https://github.com/bodil/typed-html?rev=4c13ecca#4c13ecca506887d07638cdf12d6ea6d51cd3b29a"
+dependencies = [
+ "htmlescape",
+ "language-tags",
+ "mime",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "strum",
+ "strum_macros",
+ "typed-html-macros",
+]
+
+[[package]]
+name = "typed-html-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44a4dba17ed65147f4780560f1078de857f3f4d48f5aeb2197bace8e103a7356"
+dependencies = [
+ "ansi_term",
+ "lalrpop",
+ "lalrpop-util",
+ "proc-macro-hack",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "version_check",
+]
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4439,6 +5004,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4462,7 +5033,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.6",
  "subtle",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,6 @@ humantime-serde = "1.1.1"
 slog-envlogger = "2.2.0"
 serde-this-or-that = "0.4.0"
 typed-html = { git = "https://github.com/bodil/typed-html", rev = "4c13ecca" }
-prometheus = "0.13.3"
-lazy_static = "1.4.0"
 
 [dev-dependencies]
 tokio-util = { version = "0.7.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ clap = { version = "4.0.32", features = ["derive"] }
 humantime-serde = "1.1.1"
 slog-envlogger = "2.2.0"
 serde-this-or-that = "0.4.0"
+typed-html = { git = "https://github.com/bodil/typed-html", rev = "4c13ecca" }
+prometheus = "0.13.3"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 tokio-util = { version = "0.7.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,12 @@ clap = { version = "4.0.32", features = ["derive"] }
 humantime-serde = "1.1.1"
 slog-envlogger = "2.2.0"
 serde-this-or-that = "0.4.0"
+# The public typed-html 0.2.2 release is causing a recursion limit
+# error that cannot be fixed from outside the crate.
+#
+# Rationale, 2023-03-21: https://stackoverflow.com/questions/74462753
 typed-html = { git = "https://github.com/bodil/typed-html", rev = "4c13ecca" }
+humantime = "2.1.0"
 
 [dev-dependencies]
 tokio-util = { version = "0.7.0", features = ["full"] }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,5 +1,3 @@
-use std::net::SocketAddr;
-
 /* ###################################################### System Architecture #######################################################
 
 +-----------------------------+      +----------------------------+
@@ -61,6 +59,7 @@ use {
     anyhow::Result,
     futures_util::future::join_all,
     slog::Logger,
+    std::net::SocketAddr,
     tokio::sync::{
         broadcast,
         mpsc,

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -59,7 +59,6 @@ use {
     anyhow::Result,
     futures_util::future::join_all,
     slog::Logger,
-    std::net::SocketAddr,
     tokio::sync::{
         broadcast,
         mpsc,
@@ -151,7 +150,7 @@ impl Agent {
 
         // Spawn the metrics server
         jhs.push(tokio::spawn(metrics::MetricsServer::spawn(
-            "127.0.0.1:8888".parse::<SocketAddr>()?,
+            self.config.metrics_server.bind_address,
             local_store_tx,
             global_store_lookup_tx,
             logger,
@@ -165,8 +164,10 @@ impl Agent {
 }
 
 pub mod config {
+
     use {
         super::{
+            metrics,
             pythd,
             solana::network,
         },
@@ -192,6 +193,7 @@ pub mod config {
         pub secondary_network:  Option<network::Config>,
         pub pythd_adapter:      pythd::adapter::Config,
         pub pythd_api_server:   pythd::api::rpc::Config,
+        pub metrics_server:     metrics::Config,
     }
 
     impl Config {

--- a/src/agent/metrics.rs
+++ b/src/agent/metrics.rs
@@ -30,7 +30,10 @@ use {
         },
         net::SocketAddr,
         sync::Arc,
-        time::Instant,
+        time::{
+            Duration,
+            Instant,
+        },
     },
     tokio::sync::{
         mpsc,
@@ -138,23 +141,8 @@ impl MetricsServer {
         let symbol_view =
             build_dashboard_data(local_data, global_data, global_metadata, &self.logger);
 
-        let mut uptime_seconds = self.start_time.elapsed().as_secs();
-
-        // Shave bigger units off the seconds value. Decide the count
-        // and replace with remainder.
-        let uptime_days = uptime_seconds / (24 * 3600); // 24h
-        uptime_seconds %= 24 * 3600;
-
-        let uptime_hours = uptime_seconds / 3600; // 1h
-        uptime_seconds %= 3600;
-
-        let uptime_minutes = uptime_seconds / 60; // 1min
-        uptime_seconds %= 60;
-
-        let uptime_string = format!(
-            "{}d{}h{}m{}s",
-            uptime_days, uptime_hours, uptime_minutes, uptime_seconds
-        );
+        // uptime in whole seconds
+        let uptime = Duration::from_secs(self.start_time.elapsed().as_secs());
 
         // Build and collect table rows
         let mut rows = vec![];
@@ -226,7 +214,7 @@ table, th, td {
             </head>
             <body>
             <h1>{text!(title_string)}</h1>
-        {text!("Uptime: {}", uptime_string)}
+        {text!("Uptime: {}", humantime::format_duration(uptime))}
             <h2>"State Overview"</h2>
             <table>
             <tr>

--- a/src/agent/metrics.rs
+++ b/src/agent/metrics.rs
@@ -234,11 +234,13 @@ table, th, td {
     }
 }
 
+#[derive(Debug)]
 pub struct DashboardSymbolView {
     product: Pubkey,
     prices:  BTreeMap<Pubkey, DashboardPriceView>,
 }
 
+#[derive(Debug)]
 pub struct DashboardPriceView {
     local_data:      Option<PriceInfo>,
     global_data:     Option<PriceAccount>,
@@ -337,13 +339,19 @@ pub fn build_dashboard_data(
             // Mark this product as done
             remaining_product_keys.remove(&product_key);
 
-            ret.insert(
-                symbol_name,
-                DashboardSymbolView {
-                    product: product_key,
-                    prices,
-                },
-            );
+            let symbol_view = DashboardSymbolView {
+                product: product_key,
+                prices,
+            };
+
+            if ret.contains_key(&symbol_name) {
+                warn!(logger, "Dashboard: Duplicate symbol name detected";
+                      "symbol_name" => &symbol_name,
+                      "data" => format!("{:?}", symbol_view),
+                );
+            }
+
+            ret.insert(symbol_name, symbol_view);
         } else {
             // TODO(drozdziak1): log a missing product problem. We
             // expect that missing price information is possible if no

--- a/src/agent/metrics.rs
+++ b/src/agent/metrics.rs
@@ -1,0 +1,388 @@
+use {
+    super::{
+        solana::oracle::{
+            self,
+            PriceAccount,
+            ProductAccount,
+        },
+        store::{
+            global::{
+                AllAccountsData,
+                AllAccountsMetadata,
+                Lookup,
+                PriceAccountMetadata,
+            },
+            local::{
+                Message,
+                PriceInfo,
+            },
+        },
+    },
+    chrono::NaiveDateTime,
+    prometheus::Registry,
+    pyth_sdk::{
+        Identifier,
+        PriceIdentifier,
+    },
+    slog::Logger,
+    solana_sdk::pubkey::Pubkey,
+    std::{
+        collections::{
+            BTreeMap,
+            BTreeSet,
+            HashMap,
+            HashSet,
+        },
+        net::SocketAddr,
+        sync::Arc,
+        time::Instant,
+    },
+    tokio::sync::{
+        mpsc,
+        oneshot,
+        Mutex,
+    },
+    typed_html::{
+        dom::DOMTree,
+        elements::TableContent,
+        html,
+        text,
+    },
+    warp::{
+        hyper::StatusCode,
+        reply::{
+            self,
+            WithStatus,
+        },
+        Filter,
+        Rejection,
+        Reply,
+    },
+};
+
+/// Internal metrics server state, holds state needed for serving
+/// dashboard and metrics.
+pub struct MetricsServer {
+    /// Used to pull the state of all symbols in local store
+    local_store_tx:         mpsc::Sender<Message>,
+    global_store_lookup_tx: mpsc::Sender<Lookup>,
+    /// Prometheus registry for enumerating all metrics for clients
+    registry:               Registry,
+    start_time:             Instant,
+    logger:                 Logger,
+}
+
+impl MetricsServer {
+    /// Instantiate a metrics API with a dashboard
+    pub async fn spawn(
+        addr: impl Into<SocketAddr> + 'static,
+        local_store_tx: mpsc::Sender<Message>,
+        global_store_lookup_tx: mpsc::Sender<Lookup>,
+        logger: Logger,
+    ) {
+        let server = MetricsServer {
+            local_store_tx,
+            global_store_lookup_tx,
+            registry: Registry::new(),
+            start_time: Instant::now(),
+            logger,
+        };
+
+        let shared_state = Arc::new(Mutex::new(server));
+
+        let dashboard_route = warp::path("dashboard")
+            .and(warp::path::end())
+            .and_then(move || {
+                let shared_state = shared_state.clone();
+                async move {
+                    let response = shared_state
+                        .lock()
+                        .await
+                        .render_dashboard()
+                        .await
+                        .unwrap_or_else(|e| {
+                            // Add logging here
+
+                            // Withhold failure details from client
+                            "Could not render dashboard!".to_owned()
+                        });
+                    Result::<Box<dyn Reply>, Rejection>::Ok(Box::new(reply::with_status(
+                        reply::html(response),
+                        StatusCode::OK,
+                    )))
+                }
+            });
+
+        warp::serve(dashboard_route).bind(addr).await;
+    }
+
+    /// Create an HTML view of store data
+    async fn render_dashboard(&self) -> Result<String, Box<dyn std::error::Error>> {
+        // Prepare response channel for request
+        let (local_tx, local_rx) = oneshot::channel();
+        let (global_data_tx, global_data_rx) = oneshot::channel();
+        let (global_metadata_tx, global_metadata_rx) = oneshot::channel();
+
+        // Request price data from local store
+        self.local_store_tx
+            .send(Message::LookupAllPriceInfo {
+                result_tx: local_tx,
+            })
+            .await?;
+
+        self.global_store_lookup_tx
+            .send(Lookup::LookupAllAccountsData {
+                result_tx: global_data_tx,
+            })
+            .await?;
+
+        self.global_store_lookup_tx
+            .send(Lookup::LookupAllAccountsMetadata {
+                result_tx: global_metadata_tx,
+            })
+            .await?;
+
+        // Await the results
+        let local_data = local_rx.await?;
+        let global_data = global_data_rx.await??;
+        let global_metadata = global_metadata_rx.await??;
+
+        let symbol_view =
+            build_dashboard_data(local_data, global_data, global_metadata, &self.logger);
+
+        let mut uptime_seconds = self.start_time.elapsed().as_secs();
+
+        // Shave bigger units off the seconds value. Decide the count
+        // and replace with remainder.
+        let uptime_days = uptime_seconds / (24 * 3600); // 24h
+        uptime_seconds %= 24 * 3600;
+
+        let uptime_hours = uptime_seconds / 3600; // 1h
+        uptime_seconds %= 3600;
+
+        let uptime_minutes = uptime_seconds / 60; // 1min
+        uptime_seconds %= 60;
+
+        let uptime_string = format!(
+            "{}d{}h{}m{}s",
+            uptime_days, uptime_hours, uptime_minutes, uptime_seconds
+        );
+
+        // Build and collect table rows
+        let mut rows = vec![];
+
+        for (symbol, data) in symbol_view {
+            for (price_pubkey, price_data) in data.prices {
+                let price_string = if let Some(global_data) = price_data.global_data {
+                    let expo = global_data.expo;
+                    let price_with_expo: f64 = global_data.agg.price as f64 * 10f64.powi(expo);
+                    format!("{:.2}", price_with_expo)
+                } else {
+                    "no data".to_string()
+                };
+
+                let last_publish_string = if let Some(global_data) = price_data.global_data {
+                    if let Some(datetime) =
+                        NaiveDateTime::from_timestamp_opt(global_data.timestamp, 0)
+                    {
+                        datetime.format("%Y-%m-%d %H:%M:%S").to_string()
+                    } else {
+                        format!("Invalid timestamp {}", global_data.timestamp)
+                    }
+                } else {
+                    "no data".to_string()
+                };
+
+                let last_local_update_string = if let Some(local_data) = price_data.local_data {
+                    if let Some(datetime) =
+                        NaiveDateTime::from_timestamp_opt(local_data.timestamp, 0)
+                    {
+                        datetime.format("%Y-%m-%d %H:%M:%S").to_string()
+                    } else {
+                        format!("Invalid timestamp {}", local_data.timestamp)
+                    }
+                } else {
+                    "no data".to_string()
+                };
+
+                let row_snippet = html! {
+                            <tr>
+                                <td>{text!(symbol.clone())}</td>
+                                <td>{text!(data.product.to_string())}</td>
+                <td>{text!(price_pubkey.to_string())}</td>
+                <td>{text!(price_string)}</td>
+                <td>{text!(last_publish_string)}</td>
+                <td>{text!(last_local_update_string)}</td>
+                            </tr>
+                            };
+                rows.push(row_snippet);
+            }
+        }
+
+        let title_string = concat!("Pyth Agent Dashboard - ", env!("CARGO_PKG_VERSION"));
+        let res_html: DOMTree<String> = html! {
+        <html>
+            <head>
+            <title>{text!(title_string)}</title>
+        <style>
+            """
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+table, th, td {
+  border: 1px solid;
+}
+"""
+        </style>
+            </head>
+            <body>
+            <h1>{text!(title_string)}</h1>
+        {text!("Uptime: {}", uptime_string)}
+            <h2>"State Overview"</h2>
+            <table>
+            <tr>
+                <th>"Symbol"</th>
+                <th>"Product ID"</th>
+                <th>"Price ID"</th>
+                <th>"Last Published Price"</th>
+        <th>"Last Publish Time"</th>
+        <th>"Last Local Update Time"</th>
+            </tr>
+            { rows }
+        </table>
+            </body>
+        </html>
+        };
+        Ok(res_html.to_string())
+    }
+}
+
+pub struct DashboardSymbolView {
+    product: Pubkey,
+    prices:  BTreeMap<Pubkey, DashboardPriceView>,
+}
+
+pub struct DashboardPriceView {
+    local_data:      Option<PriceInfo>,
+    global_data:     Option<PriceAccount>,
+    global_metadata: Option<PriceAccountMetadata>,
+}
+
+/// Turn global/local store state into a single per-symbol view.
+///
+/// The dashboard data comes from three sources - the global store
+/// (observed on-chain state) data, global store metadata and local
+/// store data (local state possibly not yet committed to the oracle
+/// contract).
+///
+/// The view is indexed by human-readable symbol name or a stringified
+/// public key if symbol name can't be found.
+pub fn build_dashboard_data(
+    mut local_data: HashMap<PriceIdentifier, PriceInfo>,
+    mut global_data: AllAccountsData,
+    mut global_metadata: AllAccountsMetadata,
+    logger: &Logger,
+) -> BTreeMap<String, DashboardSymbolView> {
+    let mut ret = BTreeMap::new();
+
+    debug!(logger, "Building dashboard data";
+      "local_data_len" => local_data.len(),
+      "global_data_products_len" => global_data.product_accounts.len(),
+      "global_data_prices_len" => global_data.price_accounts.len(),
+      "global_metadata_products_len" => global_metadata.product_accounts_metadata.len(),
+      "global_metadata_prices_len" => global_metadata.price_accounts_metadata.len(),
+    );
+
+    // Learn all the product/price keys in the system,
+    let all_product_keys_iter = global_metadata.product_accounts_metadata.keys().cloned();
+
+    let all_product_keys_dedup = all_product_keys_iter.collect::<HashSet<Pubkey>>();
+
+    let all_price_keys_iter = global_data
+        .price_accounts
+        .keys()
+        .chain(global_metadata.price_accounts_metadata.keys())
+        .cloned()
+        .chain(local_data.keys().map(|identifier| {
+            let bytes = identifier.to_bytes();
+            Pubkey::new_from_array(bytes)
+        }));
+
+    let mut all_price_keys_dedup = all_price_keys_iter.collect::<HashSet<Pubkey>>();
+
+    // query all the keys and assemvle them into the view
+
+    let mut remaining_product_keys = all_product_keys_dedup.clone();
+
+    for product_key in all_product_keys_dedup {
+        let _product_data = global_data.product_accounts.remove(&product_key);
+
+        if let Some(mut product_metadata) = global_metadata
+            .product_accounts_metadata
+            .remove(&product_key)
+        {
+            let symbol_name = product_metadata
+                .attr_dict
+                .get("symbol")
+                .cloned()
+                // Use product key for unnamed products
+                .unwrap_or(format!("unnamed product {}", product_key));
+
+            // Sort and deduplicate prices
+            let this_product_price_keys_dedup = product_metadata
+                .price_accounts
+                .drain(0..)
+                .collect::<BTreeSet<_>>();
+
+            let mut prices = BTreeMap::new();
+
+            // Extract information about each price
+            for price_key in this_product_price_keys_dedup {
+                let price_global_data = global_data.price_accounts.remove(&price_key);
+                let price_global_metadata =
+                    global_metadata.price_accounts_metadata.remove(&price_key);
+
+                let price_identifier = Identifier::new(price_key.clone().to_bytes());
+                let price_local_data = local_data.remove(&price_identifier);
+
+                prices.insert(
+                    price_key,
+                    DashboardPriceView {
+                        local_data:      price_local_data,
+                        global_data:     price_global_data,
+                        global_metadata: price_global_metadata,
+                    },
+                );
+                // Mark this price as done
+                all_price_keys_dedup.remove(&price_key);
+            }
+
+            // Mark this product as done
+            remaining_product_keys.remove(&product_key);
+
+            ret.insert(
+                symbol_name,
+                DashboardSymbolView {
+                    product: product_key,
+                    prices,
+                },
+            );
+        } else {
+            // TODO(drozdziak1): log a missing product problem. We
+            // expect that missing price information is possible if no
+            // on-chain queries or publishing took place yet.
+            warn!(logger, "Dashboard: Failed to look up product metadata"; "product_id" => product_key.to_string());
+        }
+    }
+
+    if !(all_price_keys_dedup.is_empty() && remaining_product_keys.is_empty()) {
+        let remaining_products: Vec<_> = remaining_product_keys.drain().collect();
+        let remaining_prices: Vec<_> = all_price_keys_dedup.drain().collect();
+        warn!(logger, "Dashboard: Orphaned product/price IDs detected";
+	      "remaining_product_ids" => format!("{:?}", remaining_products),
+	      "remaining_price_ids" => format!("{:?}", remaining_prices));
+    }
+
+    return ret;
+}

--- a/src/agent/metrics.rs
+++ b/src/agent/metrics.rs
@@ -19,6 +19,7 @@ use {
         Identifier,
         PriceIdentifier,
     },
+    serde::Deserialize,
     slog::Logger,
     solana_sdk::pubkey::Pubkey,
     std::{
@@ -53,6 +54,24 @@ use {
         Reply,
     },
 };
+
+pub fn default_bind_address() -> SocketAddr {
+    "127.0.0.1:8888".parse().unwrap()
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Config {
+    #[serde(default = "default_bind_address")]
+    pub bind_address: SocketAddr,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            bind_address: default_bind_address(),
+        }
+    }
+}
 
 /// Internal metrics server state, holds state needed for serving
 /// dashboard and metrics.

--- a/src/agent/store/local.rs
+++ b/src/agent/store/local.rs
@@ -32,6 +32,7 @@ pub struct PriceInfo {
     pub timestamp: UnixTimestamp,
 }
 
+#[derive(Debug)]
 pub enum Message {
     Update {
         price_identifier: PriceIdentifier,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 #[macro_use]
 extern crate slog;
 extern crate slog_term;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+// The typed-html crate does pretty deep macro calls. Bump if
+// recursion limit compilation errors return for html!() calls.
 #![recursion_limit = "256"]
 #[macro_use]
 extern crate slog;


### PR DESCRIPTION
# Overview
This change introduces a simple HTML table for quick reference about individual symbol status. The table is served using a new HTTP endpoint, under "/dashboard". 

# Screenshot
[click here](https://imgur.com/a/kRtTGUx)

# Changes to existing code
* The HTTP endpoint is spawned in `agent.rs` together with other async jobs. It reuses the logger and some of the channel tx's.
* Macro recursion limit is raised to 256 (the new type-checked HTML crate is macro-heavy)
* New dependencies
* * typed-html - ergonomic HTML manipulation

# New code
* `metrics.rs` - a new metrics- and dashboard oriented module. I plan to also add Prometheus metrics there and I'll probably exile dashboard generation logic to something like `dashboard.rs`. lmk if it's not okay with you.

# Testing
* The existing Pytest harness continues to pass.
* I verified my code using the example publisher and the `integration-tests` config (that's also how I generated the screenshot). The timestamps and price values update often, as expected. The rightmost "last local update time" column displays "no data" unil updates start flowing in from example publisher, as expected. In the screenshot you can notice the column contains a newer timestamp, demonstrating that the local data is more up to date     ...as expected.

# Review Highlights
* `metrics.rs` - I am not  100% happy with the readability of the code that generates the HTML and does lookups in the local/global stores. As I move this code to its own module, It will probably make more sense.