### PR TITLE
nix: nixpkgs release-22.11, solana validator 1.15.2, /usr/bin/env

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+watch_file flake.nix
+watch_file shell.nix
+watch_file flake.lock
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -38,17 +38,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1662019588,
-        "narHash": "sha256-oPEjHKGGVbBXqwwL+UjsveJzghWiWV0n9ogo1X6l4cw=",
+        "lastModified": 1678359244,
+        "narHash": "sha256-7uQFhyy4cOfURK+gIaQKGfPSlyERcD+GZWoRuwcGnq8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2da64a81275b68fdad38af669afeda43d401e94b",
+        "rev": "489de63e2d1d388e3315793baffce745e880b96c",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-unstable",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "release-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 {
   description                         = "Pyth Agent";
   nixConfig.bash-prompt               = "\[nix@pyth-agent\]$ ";
-  inputs.nixpkgs.url                  = "nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url                  = github:NixOS/nixpkgs/release-22.11;
   inputs.flake-utils.url              = "github:numtide/flake-utils";
   inputs.fenix.url                    = "github:nix-community/fenix";
   inputs.fenix.inputs.nixpkgs.follows = "nixpkgs";

--- a/nix/solana-validator.nix
+++ b/nix/solana-validator.nix
@@ -1,0 +1,93 @@
+# largely inspired from https://github.com/saber-hq/saber-overlay/blob/master/packages/solana/solana.nix
+
+{ stdenv
+, fetchFromGitHub
+, lib
+, rustPlatform
+, IOKit
+, Security
+, AppKit
+, pkg-config
+, udev
+, zlib
+, protobuf
+, clang
+, llvm
+, openssl
+, libclang
+, rustfmt
+, perl
+, hidapi
+, solanaPkgs ? [
+    "solana"
+    "solana-bench-tps"
+    "solana-faucet"
+    "solana-gossip"
+    "solana-install"
+    "solana-keygen"
+    "solana-ledger-tool"
+    "solana-log-analyzer"
+    "solana-net-shaper"
+    "solana-sys-tuner"
+    "solana-validator"
+    "cargo-build-bpf"
+    "cargo-test-bpf"
+    "solana-dos"
+    "solana-install-init"
+    "solana-stake-accounts"
+    "solana-test-validator"
+    "solana-tokens"
+    "solana-watchtower"
+  ] ++ [
+    # XXX: Ensure `solana-genesis` is built LAST!
+    # See https://github.com/solana-labs/solana/issues/5826
+    "solana-genesis"
+  ]
+}:
+let
+  version = "1.15.2";
+  extraOutputHashes = {
+    "typed-hpml-0.2.2" = "00000000000000000";
+  };
+  cargoSha256 = "sha256-G3LvsQqEFNBB0+T23+CWloOMMI8OQf2zFsCkXUP/hGU=";
+  sha256 = "sha256-rg1mshIQ5WibI8YEBSqLRhWiTcpoBNgFQjE0SZ12jqc=";
+in
+rustPlatform.buildRustPackage rec {
+  pname = "solana-validator";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "solana-labs";
+    repo = "solana";
+    rev = "v${version}";
+    inherit sha256;
+  };
+
+  # partly inspired by https://github.com/obsidiansystems/solana-bridges/blob/develop/default.nix#L29
+  inherit cargoSha256;
+  verifyCargoDeps = true;
+
+  cargoBuildFlags = builtins.map (n: "--bin=${n}") solanaPkgs;
+
+  # weird errors. see https://github.com/NixOS/nixpkgs/issues/52447#issuecomment-852079285
+  LIBCLANG_PATH = "${libclang.lib}/lib";
+  BINDGEN_EXTRA_CLANG_ARGS =
+    "-isystem ${libclang.lib}/lib/clang/${lib.getVersion clang}/include";
+  LLVM_CONFIG_PATH = "${llvm}/bin/llvm-config";
+
+  nativeBuildInputs = [ clang llvm pkg-config protobuf rustfmt perl ];
+  buildInputs =
+    [ openssl zlib libclang hidapi ] ++ (lib.optionals stdenv.isLinux [ udev ]);
+  strictDeps = true;
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Web-Scale Blockchain for fast, secure, scalable, decentralized apps and marketplaces. ";
+    homepage = "https://solana.com";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ adjacentresearch ];
+    platforms = platforms.unix;
+  };
+  passthru.updateScript = ./update.sh;
+}

--- a/scripts/init_key_store.sh
+++ b/scripts/init_key_store.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # This script initializes the keystore directory used by the agent binary.

--- a/shell.nix
+++ b/shell.nix
@@ -1,17 +1,32 @@
-{ pkgs ? import <nixpkgs> {}
+{ pkgs ? import <nixpkgs> { }
 , ...
 }:
+let
+  solana-validator-bumped = pkgs.callPackage ./nix/solana-validator.nix {
+    inherit (pkgs.apple_sdk.frameworks) IOKit Security AppKit;
+    rustPlatform = pkgs.rustPackages_1_66.rustPlatform;
+  };
 
-with pkgs; mkShell {
+in
+with pkgs;
+mkShell rec {
   buildInputs = [
     clang
     llvmPackages.libclang
+    git # the shell may be using a different glibc which upsets common CLI tools
     openssl
     pkgconfig
     rustup
+    python3
+    poetry
+    solana-validator-bumped
+    stdenv.cc
+    stdenv.cc.cc.lib # libstdc++.so.6
   ];
 
-  shellHook = ''
-    export LIBCLANG_PATH="${llvmPackages.libclang.lib}/lib";
-  '';
+  # Explicitly tell the environment about all *.so's (libstdcxx, libclang end up in the path this way)
+  LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;
+
+  # Tell the Rust build where libclang lives
+  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
 }


### PR DESCRIPTION
This makes integration tests work on NixOS, previously broken by old solana and /bin/bash in hashbang