### PR TITLE
Prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,6 +1008,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65d09067bfacaa79114679b279d7f5885b53295b1e2cfb4e79c8e4bd3d633169"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2669,25 +2675,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus"
-version = "0.13.3"
+name = "prometheus-client"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+checksum = "5d6fa99d535dd930d1249e6c79cb3c2915f9172a540fe2b02a4c8f9ca954721e"
 dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
- "memchr",
+ "dtoa",
+ "itoa",
  "parking_lot",
- "protobuf",
- "thiserror",
+ "prometheus-client-derive-encode",
 ]
 
 [[package]]
-name = "protobuf"
-version = "2.28.0"
+name = "prometheus-client-derive-encode"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "72b6a5217beb0ad503ee7fa752d451c905113d70721b937126158f3106a48cc1"
+dependencies = [
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
+]
 
 [[package]]
 name = "pyth-agent"
@@ -2707,7 +2715,7 @@ dependencies = [
  "lazy_static",
  "parking_lot",
  "portpicker",
- "prometheus",
+ "prometheus-client",
  "pyth-sdk",
  "pyth-sdk-solana",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,6 +2669,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
 name = "pyth-agent"
 version = "1.0.0"
 dependencies = [
@@ -2683,8 +2704,10 @@ dependencies = [
  "humantime-serde",
  "iobuffer",
  "jrpc",
+ "lazy_static",
  "parking_lot",
  "portpicker",
+ "prometheus",
  "pyth-sdk",
  "pyth-sdk-solana",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ serde-this-or-that = "0.4.0"
 # Rationale, 2023-03-21: https://stackoverflow.com/questions/74462753
 typed-html = { git = "https://github.com/bodil/typed-html", rev = "4c13ecca" }
 humantime = "2.1.0"
-prometheus = "0.13.3"
+prometheus-client = "0.19.0"
 lazy_static = "1.4.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ serde-this-or-that = "0.4.0"
 # Rationale, 2023-03-21: https://stackoverflow.com/questions/74462753
 typed-html = { git = "https://github.com/bodil/typed-html", rev = "4c13ecca" }
 humantime = "2.1.0"
+prometheus = "0.13.3"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 tokio-util = { version = "0.7.0", features = ["full"] }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -46,6 +46,7 @@ Note that there is an Oracle and Exporter for each network, but only one Local S
 
 ################################################################################################################################## */
 
+pub mod dashboard;
 pub mod metrics;
 pub mod pythd;
 pub mod remote_keypair_loader;

--- a/src/agent/dashboard.rs
+++ b/src/agent/dashboard.rs
@@ -1,0 +1,311 @@
+use {
+    super::{
+        solana::oracle::PriceAccount,
+        store::{
+            global::{
+                AllAccountsData,
+                AllAccountsMetadata,
+                Lookup,
+                PriceAccountMetadata,
+            },
+            local::{
+                Message,
+                PriceInfo,
+            },
+        },
+    },
+    crate::agent::metrics::MetricsServer,
+    chrono::NaiveDateTime,
+    pyth_sdk::{
+        Identifier,
+        PriceIdentifier,
+    },
+    slog::Logger,
+    solana_sdk::pubkey::Pubkey,
+    std::{
+        collections::{
+            BTreeMap,
+            BTreeSet,
+            HashMap,
+            HashSet,
+        },
+        time::Duration,
+    },
+    tokio::sync::oneshot,
+    typed_html::{
+        dom::DOMTree,
+        html,
+        text,
+    },
+};
+
+impl MetricsServer {
+    /// Create an HTML view of store data
+    pub async fn render_dashboard(&self) -> Result<String, Box<dyn std::error::Error>> {
+        // Prepare response channel for requests
+        let (local_tx, local_rx) = oneshot::channel();
+        let (global_data_tx, global_data_rx) = oneshot::channel();
+        let (global_metadata_tx, global_metadata_rx) = oneshot::channel();
+
+        // Request price data from local and global store
+        self.local_store_tx
+            .send(Message::LookupAllPriceInfo {
+                result_tx: local_tx,
+            })
+            .await?;
+
+        self.global_store_lookup_tx
+            .send(Lookup::LookupAllAccountsData {
+                result_tx: global_data_tx,
+            })
+            .await?;
+
+        self.global_store_lookup_tx
+            .send(Lookup::LookupAllAccountsMetadata {
+                result_tx: global_metadata_tx,
+            })
+            .await?;
+
+        // Await the results
+        let local_data = local_rx.await?;
+        let global_data = global_data_rx.await??;
+        let global_metadata = global_metadata_rx.await??;
+
+        let symbol_view =
+            build_dashboard_data(local_data, global_data, global_metadata, &self.logger);
+
+        // Note the uptime and adjust to whole seconds for cleaner output
+        let uptime = Duration::from_secs(self.start_time.elapsed().as_secs());
+
+        // Build and collect table rows
+        let mut rows = vec![];
+
+        for (symbol, data) in symbol_view {
+            for (price_pubkey, price_data) in data.prices {
+                let price_string = if let Some(global_data) = price_data.global_data {
+                    let expo = global_data.expo;
+                    let price_with_expo: f64 = global_data.agg.price as f64 * 10f64.powi(expo);
+                    format!("{:.2}", price_with_expo)
+                } else {
+                    "no data".to_string()
+                };
+
+                let last_publish_string = if let Some(global_data) = price_data.global_data {
+                    if let Some(datetime) =
+                        NaiveDateTime::from_timestamp_opt(global_data.timestamp, 0)
+                    {
+                        datetime.format("%Y-%m-%d %H:%M:%S").to_string()
+                    } else {
+                        format!("Invalid timestamp {}", global_data.timestamp)
+                    }
+                } else {
+                    "no data".to_string()
+                };
+
+                let last_local_update_string = if let Some(local_data) = price_data.local_data {
+                    if let Some(datetime) =
+                        NaiveDateTime::from_timestamp_opt(local_data.timestamp, 0)
+                    {
+                        datetime.format("%Y-%m-%d %H:%M:%S").to_string()
+                    } else {
+                        format!("Invalid timestamp {}", local_data.timestamp)
+                    }
+                } else {
+                    "no data".to_string()
+                };
+
+                let row_snippet = html! {
+                            <tr>
+                                <td>{text!(symbol.clone())}</td>
+                                <td>{text!(data.product.to_string())}</td>
+                <td>{text!(price_pubkey.to_string())}</td>
+                <td>{text!(price_string)}</td>
+                <td>{text!(last_publish_string)}</td>
+                <td>{text!(last_local_update_string)}</td>
+                            </tr>
+                            };
+                rows.push(row_snippet);
+            }
+        }
+
+        let title_string = concat!("Pyth Agent Dashboard - ", env!("CARGO_PKG_VERSION"));
+        let res_html: DOMTree<String> = html! {
+        <html>
+            <head>
+            <title>{text!(title_string)}</title>
+        <style>
+            """
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+table, th, td {
+  border: 1px solid;
+}
+"""
+        </style>
+            </head>
+            <body>
+            <h1>{text!(title_string)}</h1>
+        {text!("Uptime: {}", humantime::format_duration(uptime))}
+            <h2>"State Overview"</h2>
+            <table>
+            <tr>
+                <th>"Symbol"</th>
+                <th>"Product ID"</th>
+                <th>"Price ID"</th>
+                <th>"Last Published Price"</th>
+        <th>"Last Publish Time"</th>
+        <th>"Last Local Update Time"</th>
+            </tr>
+            { rows }
+        </table>
+            </body>
+        </html>
+        };
+        Ok(res_html.to_string())
+    }
+}
+
+#[derive(Debug)]
+pub struct DashboardSymbolView {
+    product: Pubkey,
+    prices:  BTreeMap<Pubkey, DashboardPriceView>,
+}
+
+#[derive(Debug)]
+pub struct DashboardPriceView {
+    local_data:      Option<PriceInfo>,
+    global_data:     Option<PriceAccount>,
+    global_metadata: Option<PriceAccountMetadata>,
+}
+
+/// Turn global/local store state into a single per-symbol view.
+///
+/// The dashboard data comes from three sources - the global store
+/// (observed on-chain state) data, global store metadata and local
+/// store data (local state possibly not yet committed to the oracle
+/// contract).
+///
+/// The view is indexed by human-readable symbol name or a stringified
+/// public key if symbol name can't be found.
+pub fn build_dashboard_data(
+    mut local_data: HashMap<PriceIdentifier, PriceInfo>,
+    mut global_data: AllAccountsData,
+    mut global_metadata: AllAccountsMetadata,
+    logger: &Logger,
+) -> BTreeMap<String, DashboardSymbolView> {
+    let mut ret = BTreeMap::new();
+
+    debug!(logger, "Building dashboard data";
+      "local_data_len" => local_data.len(),
+      "global_data_products_len" => global_data.product_accounts.len(),
+      "global_data_prices_len" => global_data.price_accounts.len(),
+      "global_metadata_products_len" => global_metadata.product_accounts_metadata.len(),
+      "global_metadata_prices_len" => global_metadata.price_accounts_metadata.len(),
+    );
+
+    // Learn all the product/price keys in the system,
+    let all_product_keys_iter = global_metadata.product_accounts_metadata.keys().cloned();
+
+    let all_product_keys_dedup = all_product_keys_iter.collect::<HashSet<Pubkey>>();
+
+    let all_price_keys_iter = global_data
+        .price_accounts
+        .keys()
+        .chain(global_metadata.price_accounts_metadata.keys())
+        .cloned()
+        .chain(local_data.keys().map(|identifier| {
+            let bytes = identifier.to_bytes();
+            Pubkey::new_from_array(bytes)
+        }));
+
+    let mut all_price_keys_dedup = all_price_keys_iter.collect::<HashSet<Pubkey>>();
+
+    // query all the keys and assemvle them into the view
+
+    let mut remaining_product_keys = all_product_keys_dedup.clone();
+
+    for product_key in all_product_keys_dedup {
+        let _product_data = global_data.product_accounts.remove(&product_key);
+
+        if let Some(mut product_metadata) = global_metadata
+            .product_accounts_metadata
+            .remove(&product_key)
+        {
+            let mut symbol_name = product_metadata
+                .attr_dict
+                .get("symbol")
+                .cloned()
+                // Use product key for unnamed products
+                .unwrap_or(format!("unnamed product {}", product_key));
+
+            // Sort and deduplicate prices
+            let this_product_price_keys_dedup = product_metadata
+                .price_accounts
+                .drain(0..)
+                .collect::<BTreeSet<_>>();
+
+            let mut prices = BTreeMap::new();
+
+            // Extract information about each price
+            for price_key in this_product_price_keys_dedup {
+                let price_global_data = global_data.price_accounts.remove(&price_key);
+                let price_global_metadata =
+                    global_metadata.price_accounts_metadata.remove(&price_key);
+
+                let price_identifier = Identifier::new(price_key.clone().to_bytes());
+                let price_local_data = local_data.remove(&price_identifier);
+
+                prices.insert(
+                    price_key,
+                    DashboardPriceView {
+                        local_data:      price_local_data,
+                        global_data:     price_global_data,
+                        global_metadata: price_global_metadata,
+                    },
+                );
+                // Mark this price as done
+                all_price_keys_dedup.remove(&price_key);
+            }
+
+            // Mark this product as done
+            remaining_product_keys.remove(&product_key);
+
+            let symbol_view = DashboardSymbolView {
+                product: product_key,
+                prices,
+            };
+
+            if ret.contains_key(&symbol_name) {
+                let new_symbol_name = format!("{} (duplicate)", symbol_name);
+
+                warn!(logger, "Dashboard: duplicate symbol name detected, renaming";
+                "symbol_name" => &symbol_name,
+                "symbol_renamed_to" => &new_symbol_name,
+                "conflicting_symbol_data" => format!("{:?}", symbol_view),
+                );
+
+                symbol_name = new_symbol_name;
+            }
+
+            ret.insert(symbol_name, symbol_view);
+        } else {
+            // This logging handles only missing products that we
+            // should have found. Missing prices are okay, appearing
+            // in cases where no on-chain queries or publishing took
+            // place yet.
+            warn!(logger, "Dashboard: Failed to look up product metadata"; "product_id" => product_key.to_string());
+        }
+    }
+
+    if !(all_price_keys_dedup.is_empty() && remaining_product_keys.is_empty()) {
+        let remaining_products: Vec<_> = remaining_product_keys.drain().collect();
+        let remaining_prices: Vec<_> = all_price_keys_dedup.drain().collect();
+        warn!(logger, "Dashboard: Orphaned product/price IDs detected";
+	      "remaining_product_ids" => format!("{:?}", remaining_products),
+	      "remaining_price_ids" => format!("{:?}", remaining_prices));
+    }
+
+    return ret;
+}

--- a/src/agent/dashboard.rs
+++ b/src/agent/dashboard.rs
@@ -1,6 +1,6 @@
 use {
     super::{
-        solana::oracle::PriceAccount,
+        solana::oracle::PriceEntry,
         store::{
             global::{
                 AllAccountsData,
@@ -176,7 +176,7 @@ pub struct DashboardSymbolView {
 #[derive(Debug)]
 pub struct DashboardPriceView {
     local_data:      Option<PriceInfo>,
-    global_data:     Option<PriceAccount>,
+    global_data:     Option<PriceEntry>,
     global_metadata: Option<PriceAccountMetadata>,
 }
 

--- a/src/agent/metrics.rs
+++ b/src/agent/metrics.rs
@@ -152,7 +152,7 @@ impl MetricsServer {
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 pub struct ProductGlobalLabels {
     pubkey: String,
-    /// Set to "unknown-<pubkey>" if not found in the attribute set
+    /// Set to "unknown_<pubkey>" if not found in the attribute set
     symbol: String,
 }
 
@@ -179,7 +179,9 @@ impl ProductGlobalMetrics {
         metrics
     }
 
-    pub fn update(&self, product_key: &Pubkey, symbol_string: String) {
+    pub fn update(&self, product_key: &Pubkey, maybe_symbol: Option<String>) {
+        let symbol_string = maybe_symbol.unwrap_or(format!("unknown_{}", product_key.to_string()));
+
         #[deny(unused_variables)]
         let Self { update_count } = self;
 

--- a/src/agent/metrics.rs
+++ b/src/agent/metrics.rs
@@ -1,50 +1,24 @@
 use {
-    super::{
-        solana::oracle::PriceEntry,
-        store::{
-            global::{
-                AllAccountsData,
-                AllAccountsMetadata,
-                Lookup,
-                PriceAccountMetadata,
-            },
-            local::{
-                Message,
-                PriceInfo,
-            },
-        },
+    super::store::{
+        global::Lookup,
+        local::Message,
     },
-    chrono::NaiveDateTime,
-    pyth_sdk::{
-        Identifier,
-        PriceIdentifier,
+    lazy_static::lazy_static,
+    prometheus::{
+        Encoder,
+        Registry,
+        TextEncoder,
     },
     serde::Deserialize,
     slog::Logger,
-    solana_sdk::pubkey::Pubkey,
     std::{
-        collections::{
-            BTreeMap,
-            BTreeSet,
-            HashMap,
-            HashSet,
-        },
         net::SocketAddr,
         sync::Arc,
-        time::{
-            Duration,
-            Instant,
-        },
+        time::Instant,
     },
     tokio::sync::{
         mpsc,
-        oneshot,
         Mutex,
-    },
-    typed_html::{
-        dom::DOMTree,
-        html,
-        text,
     },
     warp::{
         hyper::StatusCode,
@@ -73,14 +47,18 @@ impl Default for Config {
     }
 }
 
+lazy_static! {
+    pub static ref PROMETHEUS_REGISTRY: Registry = Registry::new();
+}
+
 /// Internal metrics server state, holds state needed for serving
 /// dashboard and metrics.
 pub struct MetricsServer {
     /// Used to pull the state of all symbols in local store
-    local_store_tx:         mpsc::Sender<Message>,
-    global_store_lookup_tx: mpsc::Sender<Lookup>,
-    start_time:             Instant,
-    logger:                 Logger,
+    pub local_store_tx:         mpsc::Sender<Message>,
+    pub global_store_lookup_tx: mpsc::Sender<Lookup>,
+    pub start_time:             Instant,
+    pub logger:                 Logger,
 }
 
 impl MetricsServer {
@@ -100,21 +78,22 @@ impl MetricsServer {
 
         let shared_state = Arc::new(Mutex::new(server));
 
+        let shared_state4dashboard = shared_state.clone();
         let dashboard_route = warp::path("dashboard")
             .and(warp::path::end())
             .and_then(move || {
-                let shared_state = shared_state.clone();
+                let shared_state = shared_state4dashboard.clone();
                 async move {
                     let locked_state = shared_state.lock().await;
                     let response = locked_state
-                        .render_dashboard()
+                        .render_dashboard() // Defined in a separate impl block near dashboard-specific code
                         .await
                         .unwrap_or_else(|e| {
                             // Add logging here
-			    error!(locked_state.logger,"Could not render dashboard"; "error" => e.to_string());
+			    error!(locked_state.logger,"Dashboard: Rendering failed"; "error" => e.to_string());
 
                             // Withhold failure details from client
-                            "Could not render dashboard!".to_owned()
+                            "Could not render dashboard! See the logs for details".to_owned()
                         });
                     Result::<Box<dyn Reply>, Rejection>::Ok(Box::new(reply::with_status(
                         reply::html(response),
@@ -123,269 +102,33 @@ impl MetricsServer {
                 }
             });
 
-        warp::serve(dashboard_route).bind(addr).await;
+        let shared_state4metrics = shared_state.clone();
+        let metrics_route = warp::path("metrics")
+            .and(warp::path::end())
+            .and_then(move || {
+                let shared_state = shared_state4metrics.clone();
+                async move {
+		    let locked_state = shared_state.lock().await;
+                    let encoder = TextEncoder::new();
+                    let mut buf = vec![];
+                    let response = encoder.encode(&PROMETHEUS_REGISTRY.gather(), &mut buf).map_err(|e| -> Box<dyn std::error::Error> {
+			e.into()
+		    }).and_then(|_| -> Result<_, Box<dyn std::error::Error>> {
+			let response_txt = String::from_utf8(buf)?;
+
+			Ok(Box::new(reply::with_status(response_txt, StatusCode::OK)))
+		    }).unwrap_or_else(|e| {
+			error!(locked_state.logger, "Metrics: Could not gather metrics from registry"; "error" => e.to_string());
+
+			Box::new(reply::with_status("Could not gather metrics. See logs for details".to_string(), StatusCode::INTERNAL_SERVER_ERROR))
+		    });
+
+		    Result::<Box<dyn Reply>, Rejection>::Ok(response)
+                }
+            });
+
+        warp::serve(dashboard_route.or(metrics_route))
+            .bind(addr)
+            .await;
     }
-
-    /// Create an HTML view of store data
-    async fn render_dashboard(&self) -> Result<String, Box<dyn std::error::Error>> {
-        // Prepare response channel for request
-        let (local_tx, local_rx) = oneshot::channel();
-        let (global_data_tx, global_data_rx) = oneshot::channel();
-        let (global_metadata_tx, global_metadata_rx) = oneshot::channel();
-
-        // Request price data from local store
-        self.local_store_tx
-            .send(Message::LookupAllPriceInfo {
-                result_tx: local_tx,
-            })
-            .await?;
-
-        self.global_store_lookup_tx
-            .send(Lookup::LookupAllAccountsData {
-                result_tx: global_data_tx,
-            })
-            .await?;
-
-        self.global_store_lookup_tx
-            .send(Lookup::LookupAllAccountsMetadata {
-                result_tx: global_metadata_tx,
-            })
-            .await?;
-
-        // Await the results
-        let local_data = local_rx.await?;
-        let global_data = global_data_rx.await??;
-        let global_metadata = global_metadata_rx.await??;
-
-        let symbol_view =
-            build_dashboard_data(local_data, global_data, global_metadata, &self.logger);
-
-        // uptime in whole seconds
-        let uptime = Duration::from_secs(self.start_time.elapsed().as_secs());
-
-        // Build and collect table rows
-        let mut rows = vec![];
-
-        for (symbol, data) in symbol_view {
-            for (price_pubkey, price_data) in data.prices {
-                let price_string = if let Some(global_data) = price_data.global_data {
-                    let expo = global_data.expo;
-                    let price_with_expo: f64 = global_data.agg.price as f64 * 10f64.powi(expo);
-                    format!("{:.2}", price_with_expo)
-                } else {
-                    "no data".to_string()
-                };
-
-                let last_publish_string = if let Some(global_data) = price_data.global_data {
-                    if let Some(datetime) =
-                        NaiveDateTime::from_timestamp_opt(global_data.timestamp, 0)
-                    {
-                        datetime.format("%Y-%m-%d %H:%M:%S").to_string()
-                    } else {
-                        format!("Invalid timestamp {}", global_data.timestamp)
-                    }
-                } else {
-                    "no data".to_string()
-                };
-
-                let last_local_update_string = if let Some(local_data) = price_data.local_data {
-                    if let Some(datetime) =
-                        NaiveDateTime::from_timestamp_opt(local_data.timestamp, 0)
-                    {
-                        datetime.format("%Y-%m-%d %H:%M:%S").to_string()
-                    } else {
-                        format!("Invalid timestamp {}", local_data.timestamp)
-                    }
-                } else {
-                    "no data".to_string()
-                };
-
-                let row_snippet = html! {
-                            <tr>
-                                <td>{text!(symbol.clone())}</td>
-                                <td>{text!(data.product.to_string())}</td>
-                <td>{text!(price_pubkey.to_string())}</td>
-                <td>{text!(price_string)}</td>
-                <td>{text!(last_publish_string)}</td>
-                <td>{text!(last_local_update_string)}</td>
-                            </tr>
-                            };
-                rows.push(row_snippet);
-            }
-        }
-
-        let title_string = concat!("Pyth Agent Dashboard - ", env!("CARGO_PKG_VERSION"));
-        let res_html: DOMTree<String> = html! {
-        <html>
-            <head>
-            <title>{text!(title_string)}</title>
-        <style>
-            """
-table {
-  width: 100%;
-  border-collapse: collapse;
-}
-table, th, td {
-  border: 1px solid;
-}
-"""
-        </style>
-            </head>
-            <body>
-            <h1>{text!(title_string)}</h1>
-        {text!("Uptime: {}", humantime::format_duration(uptime))}
-            <h2>"State Overview"</h2>
-            <table>
-            <tr>
-                <th>"Symbol"</th>
-                <th>"Product ID"</th>
-                <th>"Price ID"</th>
-                <th>"Last Published Price"</th>
-        <th>"Last Publish Time"</th>
-        <th>"Last Local Update Time"</th>
-            </tr>
-            { rows }
-        </table>
-            </body>
-        </html>
-        };
-        Ok(res_html.to_string())
-    }
-}
-
-#[derive(Debug)]
-pub struct DashboardSymbolView {
-    product: Pubkey,
-    prices:  BTreeMap<Pubkey, DashboardPriceView>,
-}
-
-#[derive(Debug)]
-pub struct DashboardPriceView {
-    local_data:      Option<PriceInfo>,
-    global_data:     Option<PriceEntry>,
-    global_metadata: Option<PriceAccountMetadata>,
-}
-
-/// Turn global/local store state into a single per-symbol view.
-///
-/// The dashboard data comes from three sources - the global store
-/// (observed on-chain state) data, global store metadata and local
-/// store data (local state possibly not yet committed to the oracle
-/// contract).
-///
-/// The view is indexed by human-readable symbol name or a stringified
-/// public key if symbol name can't be found.
-pub fn build_dashboard_data(
-    mut local_data: HashMap<PriceIdentifier, PriceInfo>,
-    mut global_data: AllAccountsData,
-    mut global_metadata: AllAccountsMetadata,
-    logger: &Logger,
-) -> BTreeMap<String, DashboardSymbolView> {
-    let mut ret = BTreeMap::new();
-
-    debug!(logger, "Building dashboard data";
-      "local_data_len" => local_data.len(),
-      "global_data_products_len" => global_data.product_accounts.len(),
-      "global_data_prices_len" => global_data.price_accounts.len(),
-      "global_metadata_products_len" => global_metadata.product_accounts_metadata.len(),
-      "global_metadata_prices_len" => global_metadata.price_accounts_metadata.len(),
-    );
-
-    // Learn all the product/price keys in the system,
-    let all_product_keys_iter = global_metadata.product_accounts_metadata.keys().cloned();
-
-    let all_product_keys_dedup = all_product_keys_iter.collect::<HashSet<Pubkey>>();
-
-    let all_price_keys_iter = global_data
-        .price_accounts
-        .keys()
-        .chain(global_metadata.price_accounts_metadata.keys())
-        .cloned()
-        .chain(local_data.keys().map(|identifier| {
-            let bytes = identifier.to_bytes();
-            Pubkey::new_from_array(bytes)
-        }));
-
-    let mut all_price_keys_dedup = all_price_keys_iter.collect::<HashSet<Pubkey>>();
-
-    // query all the keys and assemvle them into the view
-
-    let mut remaining_product_keys = all_product_keys_dedup.clone();
-
-    for product_key in all_product_keys_dedup {
-        let _product_data = global_data.product_accounts.remove(&product_key);
-
-        if let Some(mut product_metadata) = global_metadata
-            .product_accounts_metadata
-            .remove(&product_key)
-        {
-            let symbol_name = product_metadata
-                .attr_dict
-                .get("symbol")
-                .cloned()
-                // Use product key for unnamed products
-                .unwrap_or(format!("unnamed product {}", product_key));
-
-            // Sort and deduplicate prices
-            let this_product_price_keys_dedup = product_metadata
-                .price_accounts
-                .drain(0..)
-                .collect::<BTreeSet<_>>();
-
-            let mut prices = BTreeMap::new();
-
-            // Extract information about each price
-            for price_key in this_product_price_keys_dedup {
-                let price_global_data = global_data.price_accounts.remove(&price_key);
-                let price_global_metadata =
-                    global_metadata.price_accounts_metadata.remove(&price_key);
-
-                let price_identifier = Identifier::new(price_key.clone().to_bytes());
-                let price_local_data = local_data.remove(&price_identifier);
-
-                prices.insert(
-                    price_key,
-                    DashboardPriceView {
-                        local_data:      price_local_data,
-                        global_data:     price_global_data,
-                        global_metadata: price_global_metadata,
-                    },
-                );
-                // Mark this price as done
-                all_price_keys_dedup.remove(&price_key);
-            }
-
-            // Mark this product as done
-            remaining_product_keys.remove(&product_key);
-
-            let symbol_view = DashboardSymbolView {
-                product: product_key,
-                prices,
-            };
-
-            if ret.contains_key(&symbol_name) {
-                warn!(logger, "Dashboard: Duplicate symbol name detected";
-                      "symbol_name" => &symbol_name,
-                      "data" => format!("{:?}", symbol_view),
-                );
-            }
-
-            ret.insert(symbol_name, symbol_view);
-        } else {
-            // TODO(drozdziak1): log a missing product problem. We
-            // expect that missing price information is possible if no
-            // on-chain queries or publishing took place yet.
-            warn!(logger, "Dashboard: Failed to look up product metadata"; "product_id" => product_key.to_string());
-        }
-    }
-
-    if !(all_price_keys_dedup.is_empty() && remaining_product_keys.is_empty()) {
-        let remaining_products: Vec<_> = remaining_product_keys.drain().collect();
-        let remaining_prices: Vec<_> = all_price_keys_dedup.drain().collect();
-        warn!(logger, "Dashboard: Orphaned product/price IDs detected";
-	      "remaining_product_ids" => format!("{:?}", remaining_products),
-	      "remaining_price_ids" => format!("{:?}", remaining_prices));
-    }
-
-    return ret;
 }

--- a/src/agent/metrics.rs
+++ b/src/agent/metrics.rs
@@ -156,10 +156,10 @@ pub struct ProductGlobalLabels {
     symbol: String,
 }
 
-/// Product account global store metrics. Most fields correspond with a subset of PriceAccount fields.
+/// Product account global store metrics.
 #[derive(Default)]
 pub struct ProductGlobalMetrics {
-    /// Trivial dummy metric, reporting the pubkey underlying the human-readable symbol
+    /// How many times the global store has updated this product
     update_count: Family<ProductGlobalLabels, Counter>,
 }
 

--- a/src/agent/store/global.rs
+++ b/src/agent/store/global.rs
@@ -331,10 +331,12 @@ impl Store {
             .map(|mut sym| {
                 // Remove whitespace, preventing invalid metric names
                 sym.retain(|sym_char| !sym_char.is_whitespace());
-                sym
+
+                // Prometheus does not like slashes or dots
+                sym.replace(".", "_dot_").replace("/", "_slash_")
             })
             // Use placeholder if the attribute was not found
-            .unwrap_or(format!("unknown-{}", product_key.to_string()));
+            .unwrap_or(format!("unknown_{}", product_key.to_string()));
 
         // Denying unused var warnings and destructuring prevents
         // forgetting to use a metric field
@@ -353,7 +355,7 @@ impl Store {
                         product_key.to_string(),
                     ),
                     format!(
-                        "Dummy metric for indicating that human-readable symbol {} corresponds with product pubkey {}. Set to 'unknown-<pubkey>' if symbol is not defined.",
+                        "Dummy metric for indicating that human-readable symbol {} corresponds with product pubkey {}. To create a valid metric name, replacements are made: '. -> _dot_, / -> _slash_'; Set to 'unknown_<pubkey>' if symbol is not defined.",
                         product_key.to_string(),
                         symbol_string
                     ),

--- a/src/agent/store/global.rs
+++ b/src/agent/store/global.rs
@@ -220,12 +220,9 @@ impl Store {
             } => {
                 let attr_dict = ProductAccountMetadata::from(account.clone()).attr_dict;
 
-                let symbol_string = attr_dict
-                    .get("symbol")
-                    .cloned()
-                    .unwrap_or(format!("unknown_{}", account_key.to_string()));
+                let maybe_symbol = attr_dict.get("symbol").cloned();
 
-                self.product_metrics.update(account_key, symbol_string);
+                self.product_metrics.update(account_key, maybe_symbol);
 
                 // Update the stored data
                 self.account_data

--- a/src/agent/store/local.rs
+++ b/src/agent/store/local.rs
@@ -1,12 +1,20 @@
+use prometheus::register_counter_with_registry;
 // The Local Store stores a copy of all the price information this local publisher
 // is contributing to the network. The Exporters will then take this data and publish
 // it to the networks.
-
 use {
     super::PriceIdentifier,
+    crate::agent::metrics::PROMETHEUS_REGISTRY,
     anyhow::{
         anyhow,
         Result,
+    },
+    prometheus::{
+        register_gauge_with_registry,
+        register_int_gauge_with_registry,
+        Counter,
+        Gauge,
+        IntGauge,
     },
     pyth_sdk::{
         PriceStatus,
@@ -32,6 +40,14 @@ pub struct PriceInfo {
     pub timestamp: UnixTimestamp,
 }
 
+/// Metrics exposed to Prometheus by the local store for each price
+pub struct PriceLocalMetrics {
+    price:        IntGauge,
+    conf:         Gauge,
+    timestamp:    IntGauge,
+    update_count: Counter,
+}
+
 #[derive(Debug)]
 pub enum Message {
     Update {
@@ -48,15 +64,17 @@ pub fn spawn_store(rx: mpsc::Receiver<Message>, logger: Logger) -> JoinHandle<()
 }
 
 pub struct Store {
-    prices: HashMap<PriceIdentifier, PriceInfo>,
-    rx:     mpsc::Receiver<Message>,
-    logger: Logger,
+    prices:  HashMap<PriceIdentifier, PriceInfo>,
+    metrics: HashMap<PriceIdentifier, PriceLocalMetrics>,
+    rx:      mpsc::Receiver<Message>,
+    logger:  Logger,
 }
 
 impl Store {
     pub fn new(rx: mpsc::Receiver<Message>, logger: Logger) -> Self {
         Store {
             prices: HashMap::new(),
+            metrics: HashMap::new(),
             rx,
             logger,
         }
@@ -76,7 +94,7 @@ impl Store {
                 price_identifier,
                 price_info,
             } => {
-                self.update(price_identifier, price_info);
+                self.update(price_identifier, price_info)?;
                 Ok(())
             }
             Message::LookupAllPriceInfo { result_tx } => result_tx
@@ -85,17 +103,64 @@ impl Store {
         }
     }
 
-    pub fn update(&mut self, price_identifier: PriceIdentifier, price_info: PriceInfo) {
+    pub fn update(
+        &mut self,
+        price_identifier: PriceIdentifier,
+        price_info: PriceInfo,
+    ) -> Result<()> {
         debug!(self.logger, "local store received price update"; "identifier" => bs58::encode(price_identifier.to_bytes()).into_string());
 
         // Drop the update if it is older than the current one stored for the price
         if let Some(current_price_info) = self.prices.get(&price_identifier) {
             if current_price_info.timestamp > price_info.timestamp {
-                return;
+                return Err(anyhow!(
+                    "Received stale timestamp for price {}",
+                    price_identifier
+                ));
             }
         }
 
+        let this_price_metrics =
+            self.metrics
+                .entry(price_identifier)
+                .or_insert(PriceLocalMetrics {
+                    // Instantiate metrics if they don't exist
+                    price:        register_int_gauge_with_registry!(
+                        format!("local_{}_price", price_identifier),
+                        format!("Local Store's price value for price {}", price_identifier),
+                        PROMETHEUS_REGISTRY
+                    )?,
+                    conf:         register_gauge_with_registry!(
+                        format!("local_{}_conf", price_identifier),
+                        format!(
+                            "Local Store's confidence interval for price {}",
+                            price_identifier
+                        ),
+                        PROMETHEUS_REGISTRY
+                    )?,
+                    timestamp:    register_int_gauge_with_registry!(
+                        format!("local_{}_timestamp", price_identifier),
+                        format!("Local Store's timestamp for price {}", price_identifier),
+                        PROMETHEUS_REGISTRY
+                    )?,
+                    update_count: register_counter_with_registry!(
+                        format!("local_{}_update_count", price_identifier),
+                        format!(
+                            "Local Store's number of updates since process start for price {}",
+                            price_identifier
+                        ),
+                        PROMETHEUS_REGISTRY
+                    )?,
+                });
+
+        this_price_metrics.price.set(price_info.price);
+        this_price_metrics.conf.set(price_info.conf as f64);
+        this_price_metrics.timestamp.set(price_info.timestamp);
+        this_price_metrics.update_count.inc();
+
         self.prices.insert(price_identifier, price_info);
+
+        Ok(())
     }
 
     pub fn get_all_price_infos(&self) -> HashMap<PriceIdentifier, PriceInfo> {

--- a/src/agent/store/local.rs
+++ b/src/agent/store/local.rs
@@ -109,44 +109,6 @@ impl Store {
 
         self.metrics.update(&price_identifier, &price_info);
 
-        // let this_price_metrics =
-        //     self.metrics
-        //         .entry(price_identifier)
-        //         .or_insert(PriceLocalMetrics {
-        //             // Instantiate metrics if they don't exist
-        //             price:        register_int_gauge_with_registry!(
-        //                 format!("local_{}_price", price_identifier),
-        //                 format!("Local Store's price value for price {}", price_identifier),
-        //                 PROMETHEUS_REGISTRY
-        //             )?,
-        //             conf:         register_gauge_with_registry!(
-        //                 format!("local_{}_conf", price_identifier),
-        //                 format!(
-        //                     "Local Store's confidence interval for price {}",
-        //                     price_identifier
-        //                 ),
-        //                 PROMETHEUS_REGISTRY
-        //             )?,
-        //             timestamp:    register_int_gauge_with_registry!(
-        //                 format!("local_{}_timestamp", price_identifier),
-        //                 format!("Local Store's timestamp for price {}", price_identifier),
-        //                 PROMETHEUS_REGISTRY
-        //             )?,
-        //             update_count: register_counter_with_registry!(
-        //                 format!("local_{}_update_count", price_identifier),
-        //                 format!(
-        //                     "Local Store's number of updates since process start for price {}",
-        //                     price_identifier
-        //                 ),
-        //                 PROMETHEUS_REGISTRY
-        //             )?,
-        //         });
-
-        // this_price_metrics.price.set(price_info.price);
-        // this_price_metrics.conf.set(price_info.conf as f64);
-        // this_price_metrics.timestamp.set(price_info.timestamp);
-        // this_price_metrics.update_count.inc();
-
         self.prices.insert(price_identifier, price_info);
 
         Ok(())


### PR DESCRIPTION
This change introduces an initial set of Prometheus metrics:
* Selection of PriceInfo fields from local store
* Selection of PriceAccount fields from global store
* Selection of ProductAccount fields from global store

The metrics are constructed dynamically, depending on the symbols existing in global/local store. Relevant symbol names and pubkeys are marked using labels.

# Testing
* Tests continue to pass locally
* The full set of metrics is shown when curling the metrics endpoint (localhost:8888/metrics)

# Review Highlights
* `metrics.rs` - this diff includes moving the simple dashboard do its own module in `dashboard.rs`. Remaining volume of the diff is mostly repetitive registering and updating of the metrics objects. We guard  that all metrics are used with destructuring with errors on unused variable warnings.
