### PR TITLE
channel config: add slog buffer capacity, doc capacities in config

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -21,7 +21,45 @@ key_store.root_path = "/path/to/keystore"
 
 ### Optional fields ###
 
-# Path to publisher identity keypair. When not found, the network will expect a remote-loaded keypair. see remote_keypair_loader options for details.
+# Channel capacities. These refer to async messaging channels
+# internally used by the agent's subroutines
+
+# Capacity of the channel used to broadcast shutdown events to all
+# components
+# channel_capacities.shutdown = 10000
+
+# Capacity of the channel used to send updates from the primary Oracle
+# to the Global Store
+# channel_capacities.primary_oracle_updates = 10000
+
+# Capacity of the channel used to send updates from the secondary
+# Oracle to the Global Store
+# channel_capacities.secondary_oracle_updates = 10000
+
+# Capacity of the channel the Pythd API Adapter uses to send lookup
+# requests to the Global Store
+# channel_capacities.global_store_lookup = 10000
+
+# Capacity of the channel the Pythd API Adapter uses to communicate
+# with the Local Store
+# channel_capacities.local_store_lookup = 10000
+
+# Capacity of the channel on which the Local Store receives messages
+# channel_capacities.local_store = 10000
+
+# Capacity of the channel on which the Pythd API Adapter receives
+# messages
+# channel_capacities.pythd_adapter = 10000
+
+# Capacity of the slog logging channel. Adjust this value if you see
+# complaints about channel capacity from slog
+# channel_capacities.logger_buffer = 10000
+
+
+# Path to publisher identity keypair. When the specified path is not
+# found on startup, the relevant primary/secondary network will expect
+# a remote-loaded keypair. See remote_keypair_loader options for
+# details.
 # key_store.publish_keypair_path = "publish_key_pair.json" # I exist, remote loading disabled
 # key_store.publish_keypair_path = "none" # I do not exist, remote loading activated for the network
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -3,7 +3,7 @@
 +--------------------------------+ +--------------------------------+
 |     RPC Node, e.g. Pythnet     | | RPC Node, e.g. Solana Mainnet  |
 +--------------------------------+ +--------------------------------+
-    |                     ^            ^                     |
+|                     ^            ^                     |
 +---|---------------------|------+ +---|---------------------|------+
 |   |    Primary Network  |      | |      Secondary Network  |      |
 |   v                     |      | |   |                     v      |
@@ -39,14 +39,14 @@ Publisher data write path:
 - The Adapter then transforms this into the Pyth SDK data structures and sends it to the Local Store.
 - The Local Store holds the latest price data the user has submitted for each price feed.
 - The Exporters periodically query the Local Store for the latest user-submitted data,
-  and send it to the RPC node.
+and send it to the RPC node.
 
 Publisher data read path:
 - The Oracles continually fetch data from the RPC node, and pass this to the Global Store.
 - The Global Store holds a unified view of the latest observed data from both networks, in the Pyth SDK data structures.
 - When a user queries for this data using the Pythd JRPC Websocket API, the Adapter fetches
-  the latest data from the Global Store. It transforms this from the Pyth SDK data structures into the
-  Pythd JRPC Websocket API data structures.
+the latest data from the Global Store. It transforms this from the Pyth SDK data structures into the
+Pythd JRPC Websocket API data structures.
 - The Pythd JRPC Websocket API then sends this data to the user.
 
 Remote Keypair Loading:
@@ -270,6 +270,8 @@ pub mod config {
         pub local_store:              usize,
         /// Capacity of the channel on which the Pythd API Adapter receives messages
         pub pythd_adapter:            usize,
+        /// Capacity of the slog logging channel. Adjust this value if you see complaints about channel capacity from slog
+        pub logger_buffer:            usize,
     }
 
     impl Default for ChannelCapacities {
@@ -282,6 +284,7 @@ pub mod config {
                 local_store_lookup:       10000,
                 local_store:              10000,
                 pythd_adapter:            10000,
+                logger_buffer:            10000,
             }
         }
     }


### PR DESCRIPTION
This change should help high-throughput publishers who have seen logger channel errors. The default for the new value is very high, allowing for plenty of messages before reaching the cap. I also added all channel capacity settings to the base config.