### PR TITLE
metrics.rs: serve dashboard on http root as well

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -3,6 +3,22 @@
 # The address on which the websocket API server will listen on.
 listen_address = "127.0.0.1:8910"
 
+# Optional top-level settings
+# [metrics_server]
+# Where to serve the quick-access dashboard and metrics. Metrics live under "/metrics"
+# bind_address = "127.0.0.1:8888"
+
+# [remote_keypair_loader}
+# Where to serve the remote keypair loading endpoint, under "/primary/load_keypair" and "/secondary/load_keypair"
+#
+# NOTE: non-loopback addresses must be used carefully, making sure the
+# connection is not exposed for unauthorized access.
+# bind_address = "127.0.0.1:9001"
+
+# How much whole SOL must a keypair hold to be considered valid for use on a given network. Disabled with 0
+# primary_min_keypair_balance_sol = 1
+# secondary_min_keypair_balance_sol = 1
+
 # Configuration for the primary network this agent will publish data to. In most cases this should be a Pythnet endpoint.
 [primary_network]
 ### Required fields ###
@@ -105,18 +121,6 @@ key_store.root_path = "/path/to/keystore"
 # a value at least as large as (number of products published / number of products in a batch).
 # exporter.transaction_monitor.max_transactions = "100"
 
-# Where to serve the quick-access dashboard and metrics.
-# metrics_server.bind_address = "127.0.0.1:8888"
-
-# Where to serve the remote keypair loading endpoint, under "/primary/load_keypair" and "/secondary/load_keypair"
-#
-# NOTE: non-loopback addresses must be used carefully, making sure the
-# connection is not exposed for unauthorized access.
-# remote_keypair_loader.bind_address = "127.0.0.1:9001"
-
-# How much whole SOL must a keypair hold to be considered valid for use on a given network. Disabled with 0
-# remote_keypair_loader.primary_min_keypair_balance_sol = 1
-# remote_keypair_loader.secondary_min_keypair_balance_sol = 1
 
 # Configuration for the optional secondary network this agent will publish data to. In most cases this should be a Solana endpoint. The options correspond to the ones in primary_network
 # [secondary_network]

--- a/src/agent/metrics.rs
+++ b/src/agent/metrics.rs
@@ -99,8 +99,8 @@ impl MetricsServer {
 
         let shared_state4dashboard = shared_state.clone();
         let dashboard_route = warp::path("dashboard")
-            .and(warp::path::end())
-            .and_then(move || {
+            .or(warp::path::end())
+            .and_then(move |_| {
                 let shared_state = shared_state4dashboard.clone();
                 async move {
                     let locked_state = shared_state.lock().await;


### PR DESCRIPTION
This change makes both localhost:8888 and localhost:8888/dashboard point at the dashboard. Tested manually, integration tests continue to pass