### PR TITLE
release fixes: identifier to key in metrics,, expose metrics when testsing

### DIFF
--- a/integration-tests/agent_conf.toml
+++ b/integration-tests/agent_conf.toml
@@ -2,3 +2,6 @@
 key_store.root_path = "keystore"
 oracle.poll_interval_duration = "1s"
 exporter.transaction_monitor.poll_interval_duration = "1s"
+
+[metrics_server]
+bind_address="0.0.0.0:8888"

--- a/src/agent/metrics.rs
+++ b/src/agent/metrics.rs
@@ -411,23 +411,25 @@ impl PriceLocalMetrics {
             update_count,
         } = self;
 
+        let price_key = Pubkey::new(price_id.to_bytes().as_slice());
+
         price
             .get_or_create(&PriceLocalLabels {
-                pubkey: price_id.to_string(),
+                pubkey: price_key.to_string(),
             })
             .set(price_info.price);
         conf.get_or_create(&PriceLocalLabels {
-            pubkey: price_id.to_string(),
+            pubkey: price_key.to_string(),
         })
         .set(price_info.conf as f64);
         timestamp
             .get_or_create(&PriceLocalLabels {
-                pubkey: price_id.to_string(),
+                pubkey: price_key.to_string(),
             })
             .set(price_info.timestamp);
         update_count
             .get_or_create(&PriceLocalLabels {
-                pubkey: price_id.to_string(),
+                pubkey: price_key.to_string(),
             })
             .inc();
     }


### PR DESCRIPTION
This change polishes metrics appearance. We were using a stray PriceIdentifier for local store prices, which would appear as hex in metrics labels. This converts the identifiers back to pubkeys which print in base58