### PR TITLE
Update config.sample.pythnet.toml

### DIFF
--- a/config/config.sample.pythnet.toml
+++ b/config/config.sample.pythnet.toml
@@ -5,11 +5,11 @@ listen_address = "127.0.0.1:8910"
 
 # HTTP(S) endpoint of the RPC node. Public RPC endpoints are usually rate-limited, so a private
 # endpoint should be used in most cases.
-rpc_url = "https://pythnet.rpcpool.com"
+rpc_url = "http://api.pythnet.pyth.network:8899"
 
 # WS(S) endpoint of the RRC node. This is used to subscribe to account changes on the network.
 # This can be omitted when oracle.subscriber_enabled is set to false.
-wss_url = "wss://pythnet.rpcpool.com"
+wss_url = "ws://api.pythnet.pyth.network:8900"
 
 # Path to the key store.
 key_store.root_path = "/path/to/keystore"


### PR DESCRIPTION
publishers shouldnt be using the RPC pool pythnet endpoints unless they have a dedicated validator assigned to rpc pool (triton one). the generic public pythnet endpoints are:
[primary_network]
  rpc_url = "http://api.pythnet.pyth.network:8899/"
  wss_url = "ws://api.pythnet.pyth.network:8900/"