### PR TITLE
Drozdziak1/permissioned price accounts

### DIFF
--- a/integration-tests/tests/test_integration.py
+++ b/integration-tests/tests/test_integration.py
@@ -635,16 +635,7 @@ class TestUpdatePrice(PythTest):
         # Get the price account with which to send updates
         price_account = product["price_accounts"][0]["account"]
 
-        product_unperm = products[ETH_USD["attr_dict"]["symbol"]]
-        product_account_unperm = product_unperm["account"]
-        # Get the price account with which to send updates
-        price_account_unperm = product_unperm["price_accounts"][0]["account"]
-
         while True:
             # Send an "update_price" request
             await client.update_price(price_account, 47, 2, "trading")
             time.sleep(1)
-
-            # Send another "update_price" request to trigger aggregation
-            await client.update_price(price_account_unperm, 81, 1, "trading")
-            time.sleep(2)

--- a/integration-tests/tests/test_integration.py
+++ b/integration-tests/tests/test_integration.py
@@ -444,26 +444,24 @@ class PythTest:
             yield
 
     @pytest_asyncio.fixture
-    async def client(self, agent, tmp_path):
+    async def client(self, agent):
         client = PythAgentClient(address="ws://localhost:8910")
         await client.connect()
-        yield (client, tmp_path)
+        yield client
         await client.close()
 
     @pytest_asyncio.fixture
     async def client_hotload(self, agent_hotload):
         client = PythAgentClient(address="ws://localhost:8910")
         await client.connect()
-        yield (client, tmp_path)
+        yield client
         await client.close()
 
 
 class TestUpdatePrice(PythTest):
 
     @pytest.mark.asyncio
-    async def test_update_price_simple(self, client: (PythAgentClient, str)):
-
-        (client, tmp_path) = client
+    async def test_update_price_simple(self, client: PythAgentClient):
 
         # Fetch all products
         products = {product["attr_dict"]["symbol"]: product for product in await client.get_all_products()}
@@ -521,7 +519,7 @@ class TestUpdatePrice(PythTest):
             assert conf == 2
 
     @pytest.mark.asyncio
-    async def test_update_price_simple_with_keypair_hotload(self, client_hotload: (PythAgentClient, str)):
+    async def test_update_price_simple_with_keypair_hotload(self, client_hotload: PythAgentClient):
 
         # Hotload the keypair into running agent
         hl_request = requests.post("http://localhost:9001/primary/load_keypair", json=PUBLISHER_KEYPAIR)
@@ -531,13 +529,13 @@ class TestUpdatePrice(PythTest):
 
         LOGGER.info("Publisher keypair hotload OK")
 
+        time.sleep(3)
+
         # Continue normally with the existing simple scenario
         await self.test_update_price_simple(client_hotload)
 
     @pytest.mark.asyncio
-    async def test_update_price_discards_unpermissioned(self, client: (PythAgentClient, str)):
-
-        (client, tmp_path) = client
+    async def test_update_price_discards_unpermissioned(self, client: PythAgentClient, tmp_path):
 
         # Fetch all products
         products = {product["attr_dict"]["symbol"]: product for product in await client.get_all_products()}
@@ -618,15 +616,14 @@ class TestUpdatePrice(PythTest):
 
 
 
-
     @pytest.mark.asyncio
     @pytest.mark.skip(reason="Test not meant for automatic CI")
-    async def test_publish_forever(self, client: (PythAgentClient, str)):
+    async def test_publish_forever(self, client: PythAgentClient, tmp_path):
         '''
-        Convenience test routine for manual experiments on a running test setup.
+        Convenience test routine for manual experiments on a running
+        test setup. Comment out the skip to enable. use `-k "forever"`
+        in pytest command line to only run this scenario.
         '''
-
-        (client, tmp_path) = client
 
         # Fetch all products
         products = {product["attr_dict"]["symbol"]: product for product in await client.get_all_products()}

--- a/integration-tests/tests/test_integration.py
+++ b/integration-tests/tests/test_integration.py
@@ -475,7 +475,7 @@ class TestUpdatePrice(PythTest):
 
         # Send an "update_price" request
         await client.update_price(price_account, 42, 2, "trading")
-        time.sleep(1)
+        time.sleep(2)
 
         # Send another "update_price" request to trigger aggregation
         await client.update_price(price_account, 81, 1, "trading")

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -208,10 +208,7 @@ pub mod config {
             remote_keypair_loader,
             solana::network,
         },
-        anyhow::{
-            anyhow,
-            Result,
-        },
+        anyhow::Result,
         config as config_rs,
         config_rs::{
             Environment,

--- a/src/agent/solana.rs
+++ b/src/agent/solana.rs
@@ -75,8 +75,9 @@ pub mod network {
         keypair_request_tx: mpsc::Sender<KeypairRequest>,
         logger: Logger,
     ) -> Result<Vec<JoinHandle<()>>> {
-        // Permissioned price account updates between oracle and exporter
-        let (perm_price_tx, perm_price_rx) = mpsc::channel(config.oracle.updates_channel_capacity);
+        // Publisher permissions updates between oracle and exporter
+        let (publisher_permissions_tx, publisher_permissions_rx) =
+            mpsc::channel(config.oracle.updates_channel_capacity);
 
         // Spawn the Oracle
         let mut jhs = oracle::spawn_oracle(
@@ -85,9 +86,8 @@ pub mod network {
             &config.wss_url,
             config.rpc_timeout,
             global_store_update_tx.clone(),
-            perm_price_tx,
+            publisher_permissions_tx,
             KeyStore::new(config.key_store.clone(), &logger)?,
-            keypair_request_tx.clone(),
             logger.clone(),
         );
 
@@ -96,7 +96,7 @@ pub mod network {
             config.exporter,
             &config.rpc_url,
             config.rpc_timeout,
-            perm_price_rx,
+            publisher_permissions_rx,
             KeyStore::new(config.key_store.clone(), &logger)?,
             local_store_tx,
             keypair_request_tx,

--- a/src/agent/solana/exporter.rs
+++ b/src/agent/solana/exporter.rs
@@ -145,7 +145,7 @@ pub fn spawn_exporter(
     config: Config,
     rpc_url: &str,
     rpc_timeout: Duration,
-    perm_price_rx: mpsc::Receiver<HashSet<Pubkey>>,
+    publisher_permissions_rx: mpsc::Receiver<HashMap<Pubkey, HashSet<Pubkey>>>,
     key_store: KeyStore,
     local_store_tx: Sender<store::local::Message>,
     keypair_request_tx: mpsc::Sender<KeypairRequest>,
@@ -183,7 +183,7 @@ pub fn spawn_exporter(
         local_store_tx,
         network_state_rx,
         transactions_tx,
-        perm_price_rx,
+        publisher_permissions_rx,
         keypair_request_tx,
         logger,
     );
@@ -222,10 +222,10 @@ pub struct Exporter {
     inflight_transactions_tx: Sender<Signature>,
 
     /// Permissioned symbols as read by the oracle module
-    perm_price_rx: mpsc::Receiver<HashSet<Pubkey>>,
+    publisher_permissions_rx: mpsc::Receiver<HashMap<Pubkey, HashSet<Pubkey>>>,
 
-    /// Symbols we are permissioned to publish
-    perm_price_accounts: HashSet<Pubkey>,
+    /// Currently known permissioned prices of this publisher
+    our_prices: HashSet<Pubkey>,
 
     keypair_request_tx: Sender<KeypairRequest>,
 
@@ -241,7 +241,7 @@ impl Exporter {
         local_store_tx: Sender<store::local::Message>,
         network_state_rx: watch::Receiver<NetworkState>,
         inflight_transactions_tx: Sender<Signature>,
-        perm_price_rx: mpsc::Receiver<HashSet<Pubkey>>,
+        publisher_permissions_rx: mpsc::Receiver<HashMap<Pubkey, HashSet<Pubkey>>>,
         keypair_request_tx: mpsc::Sender<KeypairRequest>,
         logger: Logger,
     ) -> Self {
@@ -255,8 +255,8 @@ impl Exporter {
             last_published_at: HashMap::new(),
             network_state_rx,
             inflight_transactions_tx,
-            perm_price_rx,
-            perm_price_accounts: HashSet::new(),
+            publisher_permissions_rx,
+            our_prices: HashSet::new(),
             keypair_request_tx,
             logger,
         }
@@ -302,108 +302,6 @@ impl Exporter {
             })
             .collect::<Vec<_>>();
 
-        // Update permissioned accounts of this publisher from the
-        // oracle. The loop ensures that we clear the channel and use
-        // only the final, latest message; try_recv() is non-blocking.
-        loop {
-            match self.perm_price_rx.try_recv() {
-                Ok(perm_price_accounts) => {
-                    self.perm_price_accounts = perm_price_accounts;
-                    trace!(
-                        self.logger,
-                        "Exporter: read permissioned price accounts from channel";
-                        "new_value" => format!("{:?}", self.perm_price_accounts),
-                    );
-                }
-                // Expected failures when channel is empty
-                Err(TryRecvError::Empty) => {
-                    debug!(
-                        self.logger,
-                        "Exporter: No more permissioned price accounts in channel, using cached value";
-                        "cached_value" => format!("{:?}", self.perm_price_accounts),
-                    );
-                    break;
-                }
-                // Unexpected failures (channel closed, internal errors etc.)
-                Err(other) => {
-                    warn!(
-                        self.logger,
-                        "Exporter: Updating permissioned price accounts failed unexpectedly, using cached value";
-                        "cached_value" => format!("{:?}", self.perm_price_accounts),
-                        "error" => other.to_string(),
-                    );
-                    break;
-                }
-            }
-        }
-
-        // Filter out price accounts we're not permissioned to update
-        let permissioned_updates = fresh_updates
-            .into_iter()
-            .filter(|(id, _data)| {
-                let key_from_id = Pubkey::new(id.clone().to_bytes().as_slice());
-                if self.perm_price_accounts.contains(&key_from_id) {
-                    true
-                } else {
-		    // Note: This message is not an error. Some publishers have different permissions on primary/secondary networks
-                    info!(self.logger, "Exporter: Attempted to publish a price without permission, skipping";
-			  "price_account" => key_from_id.to_string(),
-			  "perm_price_accounts" => format!("{:?}", self.perm_price_accounts),);
-                    false
-                }
-            })
-            .collect::<Vec<_>>();
-
-        if permissioned_updates.is_empty() {
-            return Ok(());
-        }
-
-        // Split the updates up into batches
-        let batches = permissioned_updates.chunks(self.config.max_batch_size);
-
-        // Publish all the batches, staggering the requests over the publish interval
-        let num_batches = batches.len();
-        let mut batch_send_interval = time::interval(
-            self.config
-                .publish_interval_duration
-                .div_f64(num_batches as f64),
-        );
-        let mut batch_timestamps = HashMap::new();
-        let mut batch_futures = vec![];
-        for batch in batches {
-            batch_futures.push(self.publish_batch(batch));
-
-            for (identifier, info) in batch {
-                batch_timestamps.insert(**identifier, info.timestamp);
-            }
-
-            batch_send_interval.tick().await;
-        }
-
-        // Wait for all the update requests to complete. Note that this doesn't wait for the
-        // transactions themselves to be processed or confirmed, just the RPC requests to return.
-        join_all(batch_futures)
-            .await
-            .into_iter()
-            .collect::<Result<Vec<_>>>()?;
-
-        self.last_published_at.extend(batch_timestamps);
-
-        Ok(())
-    }
-
-    async fn fetch_local_store_contents(&self) -> Result<HashMap<PriceIdentifier, PriceInfo>> {
-        let (result_tx, result_rx) = oneshot::channel();
-        self.local_store_tx
-            .send(store::local::Message::LookupAllPriceInfo { result_tx })
-            .await
-            .map_err(|_| anyhow!("failed to send lookup price info message to local store"))?;
-        result_rx
-            .await
-            .map_err(|_| anyhow!("failed to fetch from local store"))
-    }
-
-    async fn publish_batch(&self, batch: &[(&Identifier, &PriceInfo)]) -> Result<()> {
         let publish_keypair = if let Some(kp) = self.key_store.publish_keypair.as_ref() {
             // It's impossible to sanely return a &Keypair in the
             // other if branch, so we clone the reference.
@@ -432,6 +330,143 @@ impl Exporter {
             kp
         };
 
+        self.update_our_prices(&publish_keypair.pubkey());
+
+        debug!(self.logger, "Exporter: filtering prices permissioned to us";
+               "our_prices" => format!("{:?}", self.our_prices),
+               "publish_pubkey" => publish_keypair.pubkey().to_string(),
+        );
+
+        // Filter out price accounts we're not permissioned to update
+        let permissioned_updates = fresh_updates
+            .into_iter()
+            .filter(|(id, _data)| {
+                let key_from_id = Pubkey::new(id.clone().to_bytes().as_slice());
+                if self.our_prices.contains(&key_from_id) {
+                    true
+                } else {
+                    // Note: This message is not an error. Some
+                    // publishers have different permissions on
+                    // primary/secondary networks
+                    info!(
+                    self.logger,
+                    "Exporter: Attempted to publish a price without permission, skipping";
+                    "unpermissioned_price_account" => key_from_id.to_string(),
+                    "permissioned_accounts" => format!("{:?}", self.our_prices)
+                            );
+                    false
+                }
+            })
+            .collect::<Vec<_>>();
+
+        if permissioned_updates.is_empty() {
+            return Ok(());
+        }
+
+        // Split the updates up into batches
+        let batches = permissioned_updates.chunks(self.config.max_batch_size);
+
+        // Publish all the batches, staggering the requests over the publish interval
+        let num_batches = batches.len();
+        let mut batch_send_interval = time::interval(
+            self.config
+                .publish_interval_duration
+                .div_f64(num_batches as f64),
+        );
+        let mut batch_timestamps = HashMap::new();
+        let mut batch_futures = vec![];
+        for batch in batches {
+            batch_futures.push(self.publish_batch(batch, &publish_keypair));
+
+            for (identifier, info) in batch {
+                batch_timestamps.insert(**identifier, info.timestamp);
+            }
+
+            batch_send_interval.tick().await;
+        }
+
+        // Wait for all the update requests to complete. Note that this doesn't wait for the
+        // transactions themselves to be processed or confirmed, just the RPC requests to return.
+        join_all(batch_futures)
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>>>()?;
+
+        self.last_published_at.extend(batch_timestamps);
+
+        Ok(())
+    }
+
+    /// Update permissioned prices of this publisher from oracle using
+    /// the publisher permissions channel.
+    ///
+    /// The loop ensures that we clear the channel and use
+    /// only the final, latest message; try_recv() is
+    /// non-blocking.
+    ///
+    /// Note: This behavior is similar to
+    /// tokio::sync::watch::channel(), which was not appropriate here
+    /// because its internal RwLock would complain about not being
+    /// Send with the HashMap<HashSet<Pubkey>> inside.
+    /// TODO(2023-05-05): Debug the watch::channel() compilation errors
+    fn update_our_prices(&mut self, publish_pubkey: &Pubkey) {
+        loop {
+            match self.publisher_permissions_rx.try_recv() {
+                Ok(publisher_permissions) => {
+                    self.our_prices = publisher_permissions.get(publish_pubkey) .cloned()
+            .unwrap_or_else( || {
+		warn!(
+		    self.logger,
+		    "Exporter: No permissioned prices were found for the publishing keypair on-chain. This is expected only on startup.";
+		    "publish_pubkey" => publish_pubkey.to_string(),
+		);
+		HashSet::new()
+	    });
+                    trace!(
+                        self.logger,
+                        "Exporter: read permissioned price accounts from channel";
+                        "new_value" => format!("{:?}", self.our_prices),
+                    );
+                }
+                // Expected failures when channel is empty
+                Err(TryRecvError::Empty) => {
+                    trace!(
+                        self.logger,
+                        "Exporter: No more permissioned price accounts in channel, using cached value";
+                        "cached_value" => format!("{:?}", self.our_prices),
+                    );
+                    break;
+                }
+                // Unexpected failures (channel closed, internal errors etc.)
+                Err(other) => {
+                    warn!(
+                        self.logger,
+                        "Exporter: Updating permissioned price accounts failed unexpectedly, using cached value";
+                        "cached_value" => format!("{:?}", self.our_prices),
+                        "error" => other.to_string(),
+                    );
+                    break;
+                }
+            }
+        }
+    }
+
+    async fn fetch_local_store_contents(&self) -> Result<HashMap<PriceIdentifier, PriceInfo>> {
+        let (result_tx, result_rx) = oneshot::channel();
+        self.local_store_tx
+            .send(store::local::Message::LookupAllPriceInfo { result_tx })
+            .await
+            .map_err(|_| anyhow!("failed to send lookup price info message to local store"))?;
+        result_rx
+            .await
+            .map_err(|_| anyhow!("failed to fetch from local store"))
+    }
+
+    async fn publish_batch(
+        &self,
+        batch: &[(&Identifier, &PriceInfo)],
+        publish_keypair: &Keypair,
+    ) -> Result<()> {
         let mut instructions = Vec::new();
 
         // Refresh the data in the batch
@@ -496,7 +531,7 @@ impl Exporter {
         let transaction = Transaction::new_signed_with_payer(
             &instructions,
             Some(&publish_keypair.pubkey()),
-            &vec![&publish_keypair],
+            &vec![publish_keypair],
             network_state.blockhash,
         );
 

--- a/src/agent/solana/exporter.rs
+++ b/src/agent/solana/exporter.rs
@@ -302,10 +302,6 @@ impl Exporter {
             })
             .collect::<Vec<_>>();
 
-        if fresh_updates.is_empty() {
-            return Ok(());
-        }
-
         // Update permissioned accounts of this publisher from the
         // oracle. The loop ensures that we clear the channel and use
         // only the final, latest message.
@@ -356,6 +352,10 @@ impl Exporter {
                 }
             })
             .collect::<Vec<_>>();
+
+        if permissioned_updates.is_empty() {
+            return Ok(());
+        }
 
         // Split the updates up into batches
         let batches = permissioned_updates.chunks(self.config.max_batch_size);

--- a/src/agent/solana/exporter.rs
+++ b/src/agent/solana/exporter.rs
@@ -304,7 +304,7 @@ impl Exporter {
 
         // Update permissioned accounts of this publisher from the
         // oracle. The loop ensures that we clear the channel and use
-        // only the final, latest message.
+        // only the final, latest message; try_recv() is non-blocking.
         loop {
             match self.perm_price_rx.try_recv() {
                 Ok(perm_price_accounts) => {

--- a/src/agent/solana/exporter.rs
+++ b/src/agent/solana/exporter.rs
@@ -345,7 +345,8 @@ impl Exporter {
                 if self.perm_price_accounts.contains(&key_from_id) {
                     true
                 } else {
-                    warn!(self.logger, "Exporter: Attempted to publish a price without permission, skipping";
+		    // Note: This message is not an error. Some publishers have different permissions on primary/secondary networks
+                    info!(self.logger, "Exporter: Attempted to publish a price without permission, skipping";
 			  "price_account" => key_from_id.to_string(),
 			  "perm_price_accounts" => format!("{:?}", self.perm_price_accounts),);
                     false


### PR DESCRIPTION
This change prevents the agent from publishing prices that are not permissioned to its publishing keypair, potentially limiting the burn rate of the publishers' production deployments. The invalid attempts are logged to WARN.

# How this works
*`solana.rs` - we open a channel between oracle and exporter, periodically updating the latest known set of permissioned price accounts.
* `oracle.rs` - In addition to on-chain state lookup, we filter out permissioned prices and send them over the channel to the exporter. This is done by checking the `PriceComp.publisher` field against the publish keypair from key store. 
* `exporter.rs` - Just before building price update Solana transactions, we check for permissioned price set updates on the channel. If no updates are available, pre-existing value from exporter state is used. We filter out unpermissioned symbols using this set and log them to WARN. We continue with publishing the remaining valid symbols.

# Testing
* I verified manually that the debug-level log output corresponds with the desired unpermissioned price warning in a temporary integration test.
* A new integration test is added which verifies that unpermissioned symbols logging works and does not produce transactions

# Review highlights
* Hangups and channel overflows - by creating a new async channel, we risk bugs related to empty/overflowing channels. I did my best to fall back on empty channel and never let it overflow, but you can never be too sure.

# Remaining items
* [x] Proper Integration Testing - I'm still not 100% sure how to best add this to the integration tests. Because of our choice to use an infallible tx, our only choice seems to be parsing agent or solana tx logs. I don't like this, but if we don't come up with something else, that's probably what I'll do

