### PR TITLE
oracle.rs: hotfix: Remove stray loop break

### DIFF
--- a/src/agent/solana/oracle.rs
+++ b/src/agent/solana/oracle.rs
@@ -436,7 +436,6 @@ impl Poller {
                     .or_insert(HashSet::new());
 
                 component_pub_entry.insert(price_key.clone());
-                break;
             }
         }
 


### PR DESCRIPTION
This was left in by mistake when I changed the oracle to share the whole permission set. Previously, the break was used to finish on a price early when we've found that our publisher was permissioned for it.