### PR TITLE
Cargo.toml, Cargo.lock: Release cutoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "1.2.3"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2756,9 +2756,9 @@ dependencies = [
 
 [[package]]
 name = "pyth-sdk-solana"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc0e0ab39d0543220dcba7c248161aab70e25916b2c1585057abc0856ff4e0c"
+checksum = "e1fcd2dcd063ea85004667cf5cb07f30de7387f17249df988a295e764a47b9f5"
 dependencies = [
  "borsh",
  "borsh-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "1.2.3"
+version = "1.3.0"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
Bumping the version for the upcoming release. Decided to bump the middle value to 3 because we're providing a new compatible way to interact with the publishing API (batch requests).