### PR TITLE
Change stale update log level to info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 
 [[bin]]

--- a/src/agent/store/global.rs
+++ b/src/agent/store/global.rs
@@ -236,7 +236,7 @@ impl Store {
                 // Sanity-check that we are updating with more recent data
                 if let Some(existing_price) = self.account_data.price_accounts.get(account_key) {
                     if existing_price.timestamp > account.timestamp {
-                        warn!(self.logger, "Global store: denied stale update of an existing newer price";
+                        info!(self.logger, "Global store: denied stale update of an existing newer price";
                         "price_key" => account_key.to_string(),
                         "existing_timestamp" => existing_price.timestamp,
                         "new_timestamp" => account.timestamp,


### PR DESCRIPTION
We get stale updates due to out of order price updates and it doesn't have a warning severity. It creates a lot of logs in warn level and has concerned the publishers too. This PR changes the log level of stale update message to info.