### PR TITLE
Unchanged price publishing optimization

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -109,6 +109,11 @@ key_store.root_path = "/path/to/keystore"
 # Age after which a price update is considered stale and not published
 # exporter.staleness_threshold = "5s"
 
+# Wait at least this long before publishing an unchanged price
+# state; unchanged price state means only timestamp has changed
+# with other state identical to last published state.
+# exporter.unchanged_publish_threshold = "5s"
+
 # Maximum size of a batch
 # exporter.max_batch_size = 12
 

--- a/src/agent/solana/exporter.rs
+++ b/src/agent/solana/exporter.rs
@@ -315,7 +315,7 @@ impl Exporter {
                 // Filter out unchanged price data if the max delay wasn't reached
 
                 if let Some(last_info) = self.last_published_state.get(identifier) {
-                    if (last_info.timestamp - info.timestamp)
+                    if (info.timestamp - last_info.timestamp)
                         > self.config.unchanged_publish_threshold.as_secs() as i64
                     {
                         true // max delay since last published state reached, we publish anyway

--- a/src/agent/store/local.rs
+++ b/src/agent/store/local.rs
@@ -33,6 +33,22 @@ pub struct PriceInfo {
     pub timestamp: UnixTimestamp,
 }
 
+impl PriceInfo {
+    /// Returns false if any non-timestamp fields differ with `other`. Used for last published state comparison in exporter.
+    pub fn cmp_no_timestamp(&self, other: &Self) -> bool {
+        // Prevent forgetting to use a new field if we expand the type.
+        #[deny(unused_variables)]
+        let Self {
+            status,
+            price,
+            conf,
+            timestamp: _,
+        } = self;
+
+        status == &other.status && price == &other.price && conf == &other.conf
+    }
+}
+
 #[derive(Debug)]
 pub enum Message {
     Update {


### PR DESCRIPTION
This change prevents resends of unchanged price data, limited by a delay threshold (5s by default). After the delay passes, the unchanged price will be published anyway to avoid exclusion from aggregate.  This new behavior should help decrease gas costs.

# Changes
* New option called `<network>.exporter.unchanged_publishing_threshold` (5s by default) - delay after which unchanged updates are allowed.
* Additional filtering rule in `exporter.rs`, using the new option.

# Testing
* Unit and integration tests continue to pass normally.
