### PR TITLE
Drozdziak1/global store staleness log level

### DIFF
--- a/src/agent/store/global.rs
+++ b/src/agent/store/global.rs
@@ -236,7 +236,10 @@ impl Store {
                 // Sanity-check that we are updating with more recent data
                 if let Some(existing_price) = self.account_data.price_accounts.get(account_key) {
                     if existing_price.timestamp > account.timestamp {
-                        info!(self.logger, "Global store: denied stale update of an existing newer price";
+                        // This message is not an error. It is common
+                        // for primary and secondary network to have
+                        // slight difference in their timestamps.
+                        debug!(self.logger, "Global store: ignoring stale update of an existing newer price";
                         "price_key" => account_key.to_string(),
                         "existing_timestamp" => existing_price.timestamp,
                         "new_timestamp" => account.timestamp,


### PR DESCRIPTION
Small change to avoid publisher confusion. We've seen complaints about large quantities of this message, we move it do debug to silence it by default.