### PR TITLE
Make error!() logs shorter, label log location, fix warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2738,7 +2738,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,6 +1544,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
+]
+
+[[package]]
 name = "htmlescape"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2006,6 +2017,12 @@ checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
  "hashbrown 0.12.3",
 ]
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matches"
@@ -2746,6 +2763,7 @@ dependencies = [
  "serde_json",
  "slog",
  "slog-async",
+ "slog-bunyan",
  "slog-envlogger",
  "slog-extlog",
  "slog-term",
@@ -3694,6 +3712,18 @@ dependencies = [
  "slog",
  "take_mut",
  "thread_local",
+]
+
+[[package]]
+name = "slog-bunyan"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440fd32d0423c31e4f98d76c0b62ebdb847f905aa07357197e9b41ac620af97d"
+dependencies = [
+ "hostname",
+ "slog",
+ "slog-json",
+ "time 0.3.14",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2021"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ humantime = "2.1.0"
 prometheus-client = "0.19.0"
 lazy_static = "1.4.0"
 toml_edit = "0.19.13"
+slog-bunyan = "2.4.0"
 
 [dev-dependencies]
 tokio-util = { version = "0.7.0", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -28,9 +28,16 @@ The agent takes a single `--config` CLI option, pointing at
 there, containing a minimal set of mandatory options and documentation
 comments for optional settings. **The config file must exist.**
 
+### Logging
 The logging level can be configured at runtime
 through the `RUST_LOG` environment variable using the standard
-`error|warn|info|debug|trace` levels.
+`error|warn|info|debug|trace`.
+
+#### Plain/JSON logging
+By default, pyth-agent will print plaintext log statements. This can be switched to structured JSON output with `-l json`.
+
+#### Code location in logs
+For debugging purposes, you can specify `-L` to print file/line information with each log statement. This option is disabled by default.
 
 ### Key Store Config Migration [v1.x.x LEGACY]
 Pyth agent v2.0.0 introduces a simplified program and mapping key configuration. This breaking change alters how you define program/mapping key options in your agent config:

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -92,7 +92,12 @@ impl Agent {
     }
 
     pub async fn start(&self, logger: Logger) {
-        info!(logger, "starting agent"; "config" => format!("{:?}", self.config));
+        info!(logger, "Starting {}", env!("CARGO_PKG_NAME");
+              "config" => format!("{:?}", &self.config),
+              "version" => env!("CARGO_PKG_VERSION"),
+              "cwd" => std::env::current_dir().map(|p| format!("{}", p.display())).unwrap_or("<could not get current directory>".to_owned())
+        );
+
         if let Err(err) = self.spawn(logger.clone()).await {
             error!(logger, "{}", err);
             debug!(logger, "error context"; "context" => format!("{:?}", err));

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -94,7 +94,8 @@ impl Agent {
     pub async fn start(&self, logger: Logger) {
         info!(logger, "starting agent"; "config" => format!("{:?}", self.config));
         if let Err(err) = self.spawn(logger.clone()).await {
-            error!(logger, "{:#}", err; "error" => format!("{:?}", err));
+            error!(logger, "{}", err);
+            debug!(logger, "error context"; "context" => format!("{:?}", err));
         };
     }
 

--- a/src/agent/pythd/adapter.rs
+++ b/src/agent/pythd/adapter.rs
@@ -210,7 +210,8 @@ impl Adapter {
             tokio::select! {
                 Some(message) = self.message_rx.recv() => {
                     if let Err(err) = self.handle_message(message).await {
-                        error!(self.logger, "{:#}", err; "error" => format!("{:?}", err))
+                        error!(self.logger, "{}", err);
+            debug!(self.logger, "error context"; "context" => format!("{:?}", err));
                     }
                 }
                 _ = self.shutdown_rx.recv() => {
@@ -219,7 +220,8 @@ impl Adapter {
                 }
                 _ = self.notify_price_sched_interval.tick() => {
                     if let Err(err) = self.send_notify_price_sched().await {
-                        error!(self.logger, "{:#}", err; "error" => format!("{:?}", err))
+                        error!(self.logger, "{}", err);
+            debug!(self.logger, "error context"; "context" => format!("{:?}", err));
                     }
                 }
             }

--- a/src/agent/pythd/api.rs
+++ b/src/agent/pythd/api.rs
@@ -259,7 +259,8 @@ pub mod rpc {
                         return;
                     }
 
-                    error!(self.logger, "{:#}", err; "error" => format!("{:?}", err))
+                    error!(self.logger, "{}", err);
+                    debug!(self.logger, "error context"; "context" => format!("{:?}", err));
                 }
             }
         }
@@ -617,7 +618,8 @@ pub mod rpc {
 
         pub async fn run(&self, shutdown_rx: broadcast::Receiver<()>) {
             if let Err(err) = self.serve(shutdown_rx).await {
-                error!(self.logger, "{:#}", err; "error" => format!("{:?}", err))
+                error!(self.logger, "{}", err);
+                debug!(self.logger, "error context"; "context" => format!("{:?}", err));
             }
         }
 

--- a/src/agent/solana.rs
+++ b/src/agent/solana.rs
@@ -113,10 +113,7 @@ pub mod network {
 /// The key_store module is responsible for parsing the pythd key store.
 mod key_store {
     use {
-        anyhow::{
-            Context,
-            Result,
-        },
+        anyhow::Result,
         serde::{
             de::Error,
             Deserialize,
@@ -131,11 +128,7 @@ mod key_store {
             signer::keypair,
         },
         std::{
-            fs,
-            path::{
-                Path,
-                PathBuf,
-            },
+            path::PathBuf,
             str::FromStr,
         },
     };

--- a/src/agent/solana/exporter.rs
+++ b/src/agent/solana/exporter.rs
@@ -270,7 +270,8 @@ impl Exporter {
         loop {
             self.publish_interval.tick().await;
             if let Err(err) = self.publish_updates().await {
-                error!(self.logger, "{:#}", err; "error" => format!("{:?}", err));
+                error!(self.logger, "{}", err);
+                debug!(self.logger, "error context"; "context" => format!("{:?}", err));
             }
         }
     }
@@ -367,7 +368,7 @@ impl Exporter {
         let permissioned_updates = fresh_updates
             .into_iter()
             .filter(|(id, _data)| {
-                let key_from_id = Pubkey::new(id.clone().to_bytes().as_slice());
+                let key_from_id = Pubkey::new((*id).clone().to_bytes().as_slice());
                 if self.our_prices.contains(&key_from_id) {
                     true
                 } else {
@@ -751,7 +752,8 @@ impl NetworkStateQuerier {
         loop {
             self.query_interval.tick().await;
             if let Err(err) = self.query_network_state().await {
-                error!(self.logger, "{:#}", err; "error" => format!("{:?}", err));
+                error!(self.logger, "{}", err);
+                debug!(self.logger, "error context"; "context" => format!("{:?}", err));
             }
         }
     }
@@ -867,7 +869,8 @@ mod transaction_monitor {
         pub async fn run(&mut self) {
             loop {
                 if let Err(err) = self.handle_next().await {
-                    error!(self.logger, "{:#}", err; "error" => format!("{:?}", err));
+                    error!(self.logger, "{}", err);
+                    debug!(self.logger, "error context"; "context" => format!("{:?}", err));
                 }
             }
         }

--- a/src/agent/solana/oracle.rs
+++ b/src/agent/solana/oracle.rs
@@ -196,7 +196,8 @@ impl Oracle {
     pub async fn run(&mut self) {
         loop {
             if let Err(err) = self.handle_next().await {
-                error!(self.logger, "{:#}", err; "error" => format!("{:?}", err));
+                error!(self.logger, "{}", err);
+                debug!(self.logger, "error context"; "context" => format!("{:?}", err));
             }
         }
     }
@@ -400,7 +401,8 @@ impl Poller {
             self.poll_interval.tick().await;
             info!(self.logger, "fetching all pyth account data");
             if let Err(err) = self.poll_and_send().await {
-                error!(self.logger, "{:#}", err; "error" => format!("{:?}", err));
+                error!(self.logger, "{}", err);
+                debug!(self.logger, "error context"; "context" => format!("{:?}", err));
             }
         }
     }
@@ -661,14 +663,18 @@ mod subscriber {
         pub async fn run(&self) {
             match self.start_shadow().await {
                 Ok(mut shadow_rx) => self.forward_updates(&mut shadow_rx).await,
-                Err(err) => error!(self.logger, "{:#}", err; "error" => format!("{:?}", err)),
+                Err(err) => {
+                    error!(self.logger, "{}", err);
+                    debug!(self.logger, "error context"; "context" => format!("{:?}", err));
+                }
             }
         }
 
         async fn forward_updates(&self, shadow_rx: &mut broadcast::Receiver<(Pubkey, Account)>) {
             loop {
                 if let Err(err) = self.forward_update(shadow_rx).await {
-                    error!(self.logger, "error forwarding updates: {:#}", err; "error" => format!("{:?}", err))
+                    error!(self.logger, "{}", err);
+                    debug!(self.logger, "error context"; "context" => format!("{:?}", err));
                 }
             }
         }

--- a/src/agent/store/global.rs
+++ b/src/agent/store/global.rs
@@ -74,7 +74,6 @@ impl From<oracle::ProductEntry> for ProductAccountMetadata {
     }
 }
 
-
 /// PriceAccountMetadata contains the metadata for a price account.
 #[derive(Debug, Clone)]
 pub struct PriceAccountMetadata {
@@ -185,7 +184,8 @@ impl Store {
     pub async fn run(&mut self) {
         loop {
             if let Err(err) = self.handle_next().await {
-                error!(self.logger, "{:#}", err; "error" => format!("{:?}", err));
+                error!(self.logger, "{}", err);
+                debug!(self.logger, "error context"; "context" => format!("{:?}", err));
             }
         }
     }

--- a/src/agent/store/local.rs
+++ b/src/agent/store/local.rs
@@ -84,7 +84,8 @@ impl Store {
     pub async fn run(&mut self) {
         while let Some(message) = self.rx.recv().await {
             if let Err(err) = self.handle(message) {
-                error!(self.logger, "{:#}", err; "error" => format!("{:?}", err))
+                error!(self.logger, "{}", err);
+                debug!(self.logger, "error context"; "context" => format!("{:?}", err));
             }
         }
     }

--- a/src/bin/agent.rs
+++ b/src/bin/agent.rs
@@ -49,6 +49,7 @@ async fn main() -> Result<()> {
     // A plain slog drain that sits inside an async drain instance
     let inner_drain = LogBuilder::new(
         slog_term::FullFormat::new(slog_term::TermDecorator::new().stdout().build())
+            .use_file_location()
             .build()
             .fuse(), // Yell loud on logger internal errors
     )
@@ -67,7 +68,8 @@ async fn main() -> Result<()> {
     debug!(&logger, "Current working directory"; "cwd" => cwd.display());
 
     if let Err(err) = start(config, logger.clone()).await {
-        error!(logger, "{:#}", err; "error" => format!("{:?}", err));
+        error!(logger, "{}", err);
+        debug!(logger, "error context"; "context" => format!("{:?}", err));
         return Err(err);
     }
 

--- a/src/bin/agent.rs
+++ b/src/bin/agent.rs
@@ -73,9 +73,13 @@ async fn main() -> Result<()> {
     let async_drain = match args.log_flavor {
         LogFlavor::Json => {
             // JSON output using slog-bunyan
-            let inner_drain = LogBuilder::new(slog_bunyan::new(std::io::stdout()).build().fuse())
-                .parse(&log_level)
-                .build();
+            let inner_drain = LogBuilder::new(
+                slog_bunyan::with_name(env!("CARGO_PKG_NAME"), std::io::stdout())
+                    .build()
+                    .fuse(),
+            )
+            .parse(&log_level)
+            .build();
 
             Async::new(inner_drain)
                 .chan_size(config.channel_capacities.logger_buffer)
@@ -113,9 +117,10 @@ async fn main() -> Result<()> {
     }
 
 
-    let cwd = std::env::current_dir()?;
-
-    debug!(&logger, "Current working directory"; "cwd" => cwd.display());
+    debug!(&logger, "Starting {}", env!("CARGO_PKG_NAME");
+       "version" => env!("CARGO_PKG_VERSION"),
+       "cwd" => std::env::current_dir()?.display()
+    );
 
     if let Err(err) = start(config, logger.clone()).await {
         error!(logger, "{}", err);

--- a/src/bin/agent.rs
+++ b/src/bin/agent.rs
@@ -36,7 +36,7 @@ struct Arguments {
     #[clap(short, long, default_value = "config/config.toml")]
     /// Path to configuration file
     config:     PathBuf,
-    #[clap(short, long, default_value = "json", value_enum)]
+    #[clap(short, long, default_value = "plain", value_enum)]
     /// Log flavor to use
     log_flavor: LogFlavor,
 

--- a/src/bin/agent.rs
+++ b/src/bin/agent.rs
@@ -117,11 +117,6 @@ async fn main() -> Result<()> {
     }
 
 
-    debug!(&logger, "Starting {}", env!("CARGO_PKG_NAME");
-       "version" => env!("CARGO_PKG_VERSION"),
-       "cwd" => std::env::current_dir()?.display()
-    );
-
     if let Err(err) = start(config, logger.clone()).await {
         error!(logger, "{}", err);
         debug!(logger, "error context"; "context" => format!("{:?}", err));


### PR DESCRIPTION
# Motivation
We've seen instances of massive error log volumes coming from the agent. This was made significantly worse by the multiline error backtrace output provided from the `anyhow` package. This change alters most `error!()` logs to only use the concise single-line error messages and separates backtrace printing to `debug!()` logs.

Additionally, the error locations tend to be hard to track, which is fixed by adding `use_file_location` to the logger constructor. This should automatically annotate each log message with file/line location information.

Finally, two simple warnings are fixed to clean up compilation log output.

# Testing 
* tests continue to pass locally, 
* The location information is visible in agent logs (see below for example)
* After manually reproducing, the ERRO logs became much shorter, with full context present in DEBG:
```plain
Jul 26 15:29:44.938 ERRO[src/agent/solana/exporter.rs:755:17] RPC request error: cluster version query failed: error sending request for url (http://api.pythnet.yth.network:8899/): error tryi
ng to connect: dns error: failed to lookup address information: Name or service not known, primary: true                                                                                       
Jul 26 15:29:44.938 DEBG[src/agent/solana/exporter.rs:756:17] error context, context: RPC request error: cluster version query failed: error sending request for url (http://api.pythnet.yth.ne
twork:8899/): error trying to connect: dns error: failed to lookup address information: Name or service not known                                                                              
                                                                                                                                                                                               
Caused by:                                                                                                                                                                                     
    RPC request error: cluster version query failed: error sending request for url (http://api.pythnet.yth.network:8899/): error trying to connect: dns error: failed to lookup address informa
tion: Name or service not known, primary: true                                                                                                                                                 
Jul 26 15:29:45.117 ERRO[src/agent/solana/oracle.rs:667:21] AsyncWrap error, primary: false                                                                                                    
Jul 26 15:29:45.117 DEBG[src/agent/solana/oracle.rs:668:21] error context, context: AsyncWrap error                                                                                            
                                                                                                                                                                                               
Caused by:                                                                                                                                                                                     
    channel closed, primary: false
```