### PR TITLE
Use staleness for pricing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 
 [[bin]]

--- a/config/config.toml
+++ b/config/config.toml
@@ -83,6 +83,16 @@ key_store.mapping_key = "RelevantOracleMappingAddress"
 # calculated based on the network previous prioritization fees.
 # exporter.dynamic_compute_unit_pricing_enabled = false
 
+# Maximum total compute unit fee paid for a single transaction. Defaults to 0.001 SOL. This
+# is a safety measure while using dynamic compute price to prevent the exporter from paying
+# too much for a single transaction. The default is 10**12 micro lamports (0.001 SOL).
+# exporter.maximum_total_compute_fee_micro_lamports = 1000000000000
+
+# Maximum slot gap between the current slot and the oldest slot amongst all the accounts in
+# the batch. This is used to calculate the dynamic price per compute unit. When the slot gap
+# reaches this number we will use the maximum total_compute_fee for the transaction.
+# exporter.maximum_slot_gap_for_dynamic_compute_unit_price = 25
+
 # Duration of the interval with which to poll the status of transactions.
 # It is recommended to set this to a value close to exporter.publish_interval_duration
 # exporter.transaction_monitor.poll_interval_duration = "4s"

--- a/src/agent/dashboard.rs
+++ b/src/agent/dashboard.rs
@@ -56,6 +56,7 @@ impl MetricsServer {
 
         self.global_store_lookup_tx
             .send(Lookup::LookupAllAccountsData {
+                network:   super::solana::network::Network::Primary,
                 result_tx: global_data_tx,
             })
             .await?;

--- a/src/agent/dashboard.rs
+++ b/src/agent/dashboard.rs
@@ -255,7 +255,7 @@ pub fn build_dashboard_data(
                 let price_global_metadata =
                     global_metadata.price_accounts_metadata.remove(&price_key);
 
-                let price_identifier = Identifier::new(price_key.clone().to_bytes());
+                let price_identifier = Identifier::new(price_key.to_bytes());
                 let price_local_data = local_data.remove(&price_identifier);
 
                 prices.insert(
@@ -308,5 +308,5 @@ pub fn build_dashboard_data(
 	      "remaining_price_ids" => format!("{:?}", remaining_prices));
     }
 
-    return ret;
+    ret
 }

--- a/src/agent/metrics.rs
+++ b/src/agent/metrics.rs
@@ -182,7 +182,7 @@ impl ProductGlobalMetrics {
     }
 
     pub fn update(&self, product_key: &Pubkey, maybe_symbol: Option<String>) {
-        let symbol_string = maybe_symbol.unwrap_or(format!("unknown_{}", product_key.to_string()));
+        let symbol_string = maybe_symbol.unwrap_or(format!("unknown_{}", product_key));
 
         #[deny(unused_variables)]
         let Self { update_count } = self;
@@ -413,7 +413,7 @@ impl PriceLocalMetrics {
             update_count,
         } = self;
 
-        let price_key = Pubkey::new(price_id.to_bytes().as_slice());
+        let price_key = Pubkey::from(price_id.to_bytes());
 
         price
             .get_or_create(&PriceLocalLabels {

--- a/src/agent/pythd/adapter.rs
+++ b/src/agent/pythd/adapter.rs
@@ -257,8 +257,7 @@ impl Adapter {
                 let subscription_id = self
                     .handle_subscribe_price_sched(&account.parse()?, notify_price_sched_tx)
                     .await;
-                let res = self.send(result_tx, Ok(subscription_id));
-                res
+                self.send(result_tx, Ok(subscription_id))
             }
             Message::UpdatePrice {
                 account,
@@ -618,7 +617,10 @@ mod tests {
                     PublisherAccount,
                 },
             },
-            solana,
+            solana::{
+                self,
+                network::Network,
+            },
             store::{
                 global,
                 global::AllAccountsData,
@@ -1559,9 +1561,10 @@ mod tests {
 
         // Return the account data to the adapter, from the global store
         match test_adapter.global_store_lookup_rx.recv().await.unwrap() {
-            global::Lookup::LookupAllAccountsData { result_tx } => {
-                result_tx.send(Ok(get_all_accounts_data())).unwrap()
-            }
+            global::Lookup::LookupAllAccountsData {
+                network: Network::Primary,
+                result_tx,
+            } => result_tx.send(Ok(get_all_accounts_data())).unwrap(),
             _ => panic!("Uexpected message received from adapter"),
         };
 
@@ -1784,9 +1787,10 @@ mod tests {
 
         // Return the account data to the adapter, from the global store
         match test_adapter.global_store_lookup_rx.recv().await.unwrap() {
-            global::Lookup::LookupAllAccountsData { result_tx } => {
-                result_tx.send(Ok(get_all_accounts_data())).unwrap()
-            }
+            global::Lookup::LookupAllAccountsData {
+                network: Network::Primary,
+                result_tx,
+            } => result_tx.send(Ok(get_all_accounts_data())).unwrap(),
             _ => panic!("Uexpected message received from adapter"),
         };
 

--- a/src/agent/pythd/adapter.rs
+++ b/src/agent/pythd/adapter.rs
@@ -359,7 +359,10 @@ impl Adapter {
     async fn lookup_all_accounts_data(&self) -> Result<AllAccountsData> {
         let (result_tx, result_rx) = oneshot::channel();
         self.global_store_lookup_tx
-            .send(global::Lookup::LookupAllAccountsData { result_tx })
+            .send(global::Lookup::LookupAllAccountsData {
+                network: solana::network::Network::Primary,
+                result_tx,
+            })
             .await?;
         result_rx.await?
     }

--- a/src/agent/remote_keypair_loader.rs
+++ b/src/agent/remote_keypair_loader.rs
@@ -89,7 +89,7 @@ impl RemoteKeypairLoader {
         config: Config,
         logger: Logger,
     ) -> Vec<JoinHandle<()>> {
-        let bind_address = config.bind_address.clone();
+        let bind_address = config.bind_address;
 
         let ip = bind_address.ip();
 
@@ -181,7 +181,7 @@ impl RemoteKeypairLoader {
         );
 
         // WARNING: All jobs spawned here must report their join handles in this vec
-        return vec![request_handler_jh, http_api_jh];
+        vec![request_handler_jh, http_api_jh]
     }
 
     /// Validate and apply a keypair to the specified mut reference,

--- a/src/agent/solana/exporter.rs
+++ b/src/agent/solana/exporter.rs
@@ -35,10 +35,8 @@ use {
     solana_client::{
         nonblocking::rpc_client::RpcClient,
         rpc_config::RpcSendTransactionConfig,
-        rpc_response::RpcPrioritizationFee,
     },
     solana_sdk::{
-        bs58,
         commitment_config::CommitmentConfig,
         compute_budget::ComputeBudgetInstruction,
         hash::Hash,
@@ -334,7 +332,7 @@ impl Exporter {
         let permissioned_updates = self.get_permissioned_updates().await?;
         let price_accounts = permissioned_updates
             .iter()
-            .map(|(identifier, _)| Pubkey::new(&identifier.to_bytes()))
+            .map(|(identifier, _)| Pubkey::from(identifier.to_bytes()))
             .collect::<Vec<_>>();
         self.recent_compute_unit_price_micro_lamports = self
             .estimate_compute_unit_price_micro_lamports(&price_accounts)
@@ -470,7 +468,7 @@ impl Exporter {
         Ok(fresh_updates
             .into_iter()
             .filter(|(id, _data)| {
-                let key_from_id = Pubkey::new((*id).clone().to_bytes().as_slice());
+                let key_from_id = Pubkey::from((*id).clone().to_bytes());
                 if self.our_prices.contains(&key_from_id) {
                     true
                 } else {
@@ -628,7 +626,7 @@ impl Exporter {
         });
         let price_accounts = refreshed_batch
             .clone()
-            .map(|(identifier, _)| Pubkey::new(&identifier.to_bytes()))
+            .map(|(identifier, _)| Pubkey::from(identifier.to_bytes()))
             .collect::<Vec<_>>();
 
         let network_state = *self.network_state_rx.borrow();
@@ -645,16 +643,16 @@ impl Exporter {
             {
                 self.create_instruction_with_accumulator(
                     publish_keypair.pubkey(),
-                    Pubkey::new(&identifier.to_bytes()),
-                    &price_info,
+                    Pubkey::from(identifier.to_bytes()),
+                    price_info,
                     network_state.current_slot,
                     accumulator_program_key,
                 )?
             } else {
                 self.create_instruction_without_accumulator(
                     publish_keypair.pubkey(),
-                    Pubkey::new(&identifier.to_bytes()),
-                    &price_info,
+                    Pubkey::from(identifier.to_bytes()),
+                    price_info,
                     network_state.current_slot,
                 )?
             };

--- a/src/agent/solana/oracle.rs
+++ b/src/agent/solana/oracle.rs
@@ -148,7 +148,7 @@ pub fn spawn_oracle(
             wss_url.to_string(),
             rpc_timeout,
             config.commitment,
-            key_store.program_key.clone(),
+            key_store.program_key,
             updates_tx,
             logger.clone(),
         );
@@ -322,7 +322,7 @@ impl Oracle {
     ) -> Result<()> {
         self.global_store_tx
             .send(global::Update::ProductAccountUpdate {
-                account_key: account_key.clone(),
+                account_key: *account_key,
                 account:     account.clone(),
             })
             .await
@@ -336,8 +336,8 @@ impl Oracle {
     ) -> Result<()> {
         self.global_store_tx
             .send(global::Update::PriceAccountUpdate {
-                account_key: account_key.clone(),
-                account:     account.clone(),
+                account_key: *account_key,
+                account:     *account,
             })
             .await
             .map_err(|_| anyhow!("failed to notify price account update"))
@@ -437,7 +437,7 @@ impl Poller {
                     .entry(component.publisher)
                     .or_insert(HashSet::new());
 
-                component_pub_entry.insert(price_key.clone());
+                component_pub_entry.insert(*price_key);
             }
         }
 
@@ -488,7 +488,7 @@ impl Poller {
                 .iter()
                 .filter(|pubkey| **pubkey != Pubkey::default())
             {
-                product_keys.push(account_key.clone());
+                product_keys.push(*account_key);
             }
         }
 
@@ -578,7 +578,7 @@ impl Poller {
                     }
 
                     if price.next != Pubkey::default() {
-                        next_todo.push(price.next.clone());
+                        next_todo.push(price.next);
                     }
                 } else {
                     warn!(self.logger, "Could not look up price account on chain, skipping"; "price_key" => price_key.to_string(),);

--- a/src/bin/agent.rs
+++ b/src/bin/agent.rs
@@ -116,7 +116,6 @@ async fn main() -> Result<()> {
         ));
     }
 
-
     if let Err(err) = start(config, logger.clone()).await {
         error!(logger, "{}", err);
         debug!(logger, "error context"; "context" => format!("{:?}", err));

--- a/src/bin/agent_migrate_config.rs
+++ b/src/bin/agent_migrate_config.rs
@@ -66,7 +66,7 @@ pub fn main() -> Result<()> {
     eprintln!("Migration OK. Result:");
     std::io::stderr().flush()?;
 
-    println!("{}", doc.to_string());
+    println!("{}", doc);
 
     Ok(())
 }


### PR DESCRIPTION
This PR adds dynamic (exponential) pricing based on staleness of the feeds that the publishers publish. This feature, combined with the recent fees for the price updates causes the spike on fee to last some time before going away.

The second commit contains a little refactoring to fix warnings. Please review commit-by-commit.