### PR TITLE
fix: use publisher latest slot for staleness based pricing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "2.3.0"
+version = "2.3.1"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
This PR will use the latest slot of the publisher for staleness pricing. The issues that this solve is a publisher publishing for a not yet live feed and also a publisher publishing during market close hours. We can roll out this change to all the publishers without the market-close change and it should be similarly effective.

This change also includes changing the default variables for staleness gap and max paid price for priority fees.
- staleness gap rationale: the rpc might be a bit behind by a few slots. Considering this delay and the exponential pricing this should change the unit price when the feed is really getting stale and doubling if it is still stale.
- max paid price: the lowered value will result in almost 5m priority fee which is very high.

We will modify them later based on the performance of the publishers.