### PR TITLE
exporter: Use market hours information in price filtering

### DIFF
--- a/integration-tests/tests/test_integration.py
+++ b/integration-tests/tests/test_integration.py
@@ -78,7 +78,7 @@ AAPL_USD = {
         "nasdaq_symbol": "AAPL",
         "symbol": "Equity.US.AAPL/USD",
         "base": "AAPL",
-        "market_hours": "America/New_York,C,C,C,C,C,C,C" # Should never be published due to all-closed market hours
+        "weekly_schedule": "America/New_York,C,C,C,C,C,C,C" # Should never be published due to all-closed market hours
     },
     "metadata": {"jump_id": "186", "jump_symbol": "AAPL", "price_exp": -5, "min_publishers": 1},
 }

--- a/src/agent/market_hours.rs
+++ b/src/agent/market_hours.rs
@@ -458,6 +458,8 @@ mod tests {
         assert!(wsched_eu.can_publish_at(&dt2.with_timezone(&Utc)));
         assert!(!wsched_us.can_publish_at(&dt2.with_timezone(&Utc)));
 
+        assert_eq!(dt1, dt2);
+
         // Monday after EU change, before US change, from Chicago
         // perspective. Okay for publishing Chicago market, outside
         // hours for publishing Amsterdam market.
@@ -478,6 +480,49 @@ mod tests {
 
         assert!(!wsched_eu.can_publish_at(&dt4.with_timezone(&Utc)));
         assert!(wsched_us.can_publish_at(&dt4.with_timezone(&Utc)));
+
+        assert_eq!(dt3, dt4);
+
+        // Monday after both Amsterdam and Chicago get over their DST
+        // change, from Amsterdam perspective. Okay for publishing
+        // both markets.
+        let dt5 = NaiveDateTime::parse_from_str("2023-11-06 09:01", format)?
+            .and_local_timezone(Tz::Europe__Amsterdam)
+            .unwrap();
+        dbg!(&dt5);
+        assert!(wsched_eu.can_publish_at(&dt5.with_timezone(&Utc)));
+        assert!(wsched_us.can_publish_at(&dt5.with_timezone(&Utc)));
+
+        // Same point in time, from Chicago perspective
+        let dt6 = NaiveDateTime::parse_from_str("2023-11-06 02:01", format)?
+            .and_local_timezone(Tz::America__Chicago)
+            .unwrap();
+        dbg!(&dt6);
+        assert!(wsched_eu.can_publish_at(&dt6.with_timezone(&Utc)));
+        assert!(wsched_us.can_publish_at(&dt6.with_timezone(&Utc)));
+
+        assert_eq!(dt5, dt6);
+
+        // Monday after both Amsterdam and Chicago get over their DST
+        // change, from Amsterdam perspective. Outside both markets'
+        // hours.
+        let dt7 = NaiveDateTime::parse_from_str("2023-11-06 17:01", format)?
+            .and_local_timezone(Tz::Europe__Amsterdam)
+            .unwrap();
+        dbg!(&dt7);
+        assert!(!wsched_eu.can_publish_at(&dt7.with_timezone(&Utc)));
+        assert!(!wsched_us.can_publish_at(&dt7.with_timezone(&Utc)));
+
+        // Same point in time, from Chicago perspective, still outside
+        // hours for both markets.
+        let dt8 = NaiveDateTime::parse_from_str("2023-11-06 10:01", format)?
+            .and_local_timezone(Tz::America__Chicago)
+            .unwrap();
+        dbg!(&dt8);
+        assert!(!wsched_eu.can_publish_at(&dt8.with_timezone(&Utc)));
+        assert!(!wsched_us.can_publish_at(&dt8.with_timezone(&Utc)));
+
+        assert_eq!(dt7, dt8);
 
         Ok(())
     }

--- a/src/agent/metrics.rs
+++ b/src/agent/metrics.rs
@@ -40,9 +40,7 @@ use {
     },
     warp::{
         hyper::StatusCode,
-        reply::{
-            self,
-        },
+        reply::{self,},
         Filter,
         Rejection,
         Reply,

--- a/src/agent/metrics.rs
+++ b/src/agent/metrics.rs
@@ -40,7 +40,9 @@ use {
     },
     warp::{
         hyper::StatusCode,
-        reply::{self,},
+        reply::{
+            self,
+        },
         Filter,
         Rejection,
         Reply,

--- a/src/agent/pythd/adapter.rs
+++ b/src/agent/pythd/adapter.rs
@@ -992,6 +992,7 @@ mod tests {
                                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                             ],
                         },
+                        market_hours:   Default::default(),
                         price_accounts: vec![
                             solana_sdk::pubkey::Pubkey::from_str(
                                 "GVXRSBjFk6e6J3NbVPXohDJetcTjaeeuykUpbQF8UoMU",
@@ -1051,6 +1052,7 @@ mod tests {
                                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                             ],
                         },
+                        market_hours:   Default::default(),
                         price_accounts: vec![
                             solana_sdk::pubkey::Pubkey::from_str(
                                 "GG3FTE7xhc9Diy7dn9P6BWzoCrAEE4D3p5NBYrDAm5DD",

--- a/src/agent/pythd/adapter.rs
+++ b/src/agent/pythd/adapter.rs
@@ -955,7 +955,7 @@ mod tests {
                     )
                     .unwrap(),
                     solana::oracle::ProductEntry {
-                        account_data:   pyth_sdk_solana::state::ProductAccount {
+                        account_data:    pyth_sdk_solana::state::ProductAccount {
                             magic:  0xa1b2c3d4,
                             ver:    6,
                             atype:  4,
@@ -992,8 +992,8 @@ mod tests {
                                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                             ],
                         },
-                        market_hours:   Default::default(),
-                        price_accounts: vec![
+                        weekly_schedule: Default::default(),
+                        price_accounts:  vec![
                             solana_sdk::pubkey::Pubkey::from_str(
                                 "GVXRSBjFk6e6J3NbVPXohDJetcTjaeeuykUpbQF8UoMU",
                             )
@@ -1015,7 +1015,7 @@ mod tests {
                     )
                     .unwrap(),
                     solana::oracle::ProductEntry {
-                        account_data:   pyth_sdk_solana::state::ProductAccount {
+                        account_data:    pyth_sdk_solana::state::ProductAccount {
                             magic:  0xa1b2c3d4,
                             ver:    5,
                             atype:  3,
@@ -1052,8 +1052,8 @@ mod tests {
                                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                             ],
                         },
-                        market_hours:   Default::default(),
-                        price_accounts: vec![
+                        weekly_schedule: Default::default(),
+                        price_accounts:  vec![
                             solana_sdk::pubkey::Pubkey::from_str(
                                 "GG3FTE7xhc9Diy7dn9P6BWzoCrAEE4D3p5NBYrDAm5DD",
                             )

--- a/src/agent/solana/exporter.rs
+++ b/src/agent/solana/exporter.rs
@@ -9,9 +9,12 @@ use {
         key_store,
         network::Network,
     },
-    crate::agent::remote_keypair_loader::{
-        KeypairRequest,
-        RemoteKeypairLoader,
+    crate::agent::{
+        market_hours::MarketHours,
+        remote_keypair_loader::{
+            KeypairRequest,
+            RemoteKeypairLoader,
+        },
     },
     anyhow::{
         anyhow,
@@ -19,7 +22,10 @@ use {
         Result,
     },
     bincode::Options,
-    chrono::Utc,
+    chrono::{
+        Local,
+        Utc,
+    },
     futures_util::future::{
         self,
         join_all,
@@ -169,7 +175,7 @@ pub fn spawn_exporter(
     network: Network,
     rpc_url: &str,
     rpc_timeout: Duration,
-    publisher_permissions_rx: mpsc::Receiver<HashMap<Pubkey, HashSet<Pubkey>>>,
+    publisher_permissions_rx: mpsc::Receiver<HashMap<Pubkey, HashMap<Pubkey, MarketHours>>>,
     key_store: KeyStore,
     local_store_tx: Sender<store::local::Message>,
     global_store_tx: Sender<store::global::Lookup>,
@@ -256,11 +262,11 @@ pub struct Exporter {
     // Channel on which to send inflight transactions to the transaction monitor
     inflight_transactions_tx: Sender<Signature>,
 
-    /// Permissioned symbols as read by the oracle module
-    publisher_permissions_rx: mpsc::Receiver<HashMap<Pubkey, HashSet<Pubkey>>>,
+    /// publisher => { permissioned_price => market hours } as read by the oracle module
+    publisher_permissions_rx: mpsc::Receiver<HashMap<Pubkey, HashMap<Pubkey, MarketHours>>>,
 
-    /// Currently known permissioned prices of this publisher
-    our_prices: HashSet<Pubkey>,
+    /// Currently known permissioned prices of this publisher along with their market hours
+    our_prices: HashMap<Pubkey, MarketHours>,
 
     /// Interval to update the dynamic price (if enabled)
     dynamic_compute_unit_price_update_interval: Interval,
@@ -284,7 +290,7 @@ impl Exporter {
         global_store_tx: Sender<store::global::Lookup>,
         network_state_rx: watch::Receiver<NetworkState>,
         inflight_transactions_tx: Sender<Signature>,
-        publisher_permissions_rx: mpsc::Receiver<HashMap<Pubkey, HashSet<Pubkey>>>,
+        publisher_permissions_rx: mpsc::Receiver<HashMap<Pubkey, HashMap<Pubkey, MarketHours>>>,
         keypair_request_tx: mpsc::Sender<KeypairRequest>,
         logger: Logger,
     ) -> Self {
@@ -301,7 +307,7 @@ impl Exporter {
             network_state_rx,
             inflight_transactions_tx,
             publisher_permissions_rx,
-            our_prices: HashSet::new(),
+            our_prices: HashMap::new(),
             dynamic_compute_unit_price_update_interval: tokio::time::interval(
                 time::Duration::from_secs(1),
             ),
@@ -468,13 +474,24 @@ impl Exporter {
                "publish_pubkey" => publish_keypair.pubkey().to_string(),
         );
 
+        let now = Local::now();
+
         // Filter out price accounts we're not permissioned to update
         Ok(fresh_updates
             .into_iter()
             .filter(|(id, _data)| {
                 let key_from_id = Pubkey::from((*id).clone().to_bytes());
-                if self.our_prices.contains(&key_from_id) {
-                    true
+                if let Some(market_hours) = self.our_prices.get(&key_from_id) {
+                    let ret = market_hours.can_publish_at(&now);
+
+		    if !ret {
+			debug!(self.logger, "Exporter: Attempted to publish price outside market hours";
+			       "price_account" => key_from_id.to_string(),
+			       "market_hours" => format!("{:?}", market_hours),
+			       );
+		    }
+
+		    ret
                 } else {
                     // Note: This message is not an error. Some
                     // publishers have different permissions on
@@ -570,7 +587,7 @@ impl Exporter {
                                 "Exporter: No permissioned prices were found for the publishing keypair on-chain. This is expected only on startup.";
                                 "publish_pubkey" => publish_pubkey.to_string(),
                             );
-                            HashSet::new()
+                            HashMap::new()
                         });
                     trace!(
                         self.logger,

--- a/src/agent/solana/oracle.rs
+++ b/src/agent/solana/oracle.rs
@@ -1,3 +1,4 @@
+use crate::agent::market_hours::MarketHours;
 // This module is responsible for loading the current state of the
 // on-chain Oracle program accounts from Solana.
 use {
@@ -47,8 +48,8 @@ pub struct Data {
     pub mapping_accounts:      HashMap<Pubkey, MappingAccount>,
     pub product_accounts:      HashMap<Pubkey, ProductEntry>,
     pub price_accounts:        HashMap<Pubkey, PriceEntry>,
-    /// publisher => {their permissioned price accounts}
-    pub publisher_permissions: HashMap<Pubkey, HashSet<Pubkey>>,
+    /// publisher => {their permissioned price accounts => market hours}
+    pub publisher_permissions: HashMap<Pubkey, HashMap<Pubkey, MarketHours>>,
 }
 
 impl Data {
@@ -56,7 +57,7 @@ impl Data {
         mapping_accounts: HashMap<Pubkey, MappingAccount>,
         product_accounts: HashMap<Pubkey, ProductEntry>,
         price_accounts: HashMap<Pubkey, PriceEntry>,
-        publisher_permissions: HashMap<Pubkey, HashSet<Pubkey>>,
+        publisher_permissions: HashMap<Pubkey, HashMap<Pubkey, MarketHours>>,
     ) -> Self {
         Data {
             mapping_accounts,
@@ -71,6 +72,7 @@ pub type MappingAccount = pyth_sdk_solana::state::MappingAccount;
 #[derive(Debug, Clone)]
 pub struct ProductEntry {
     pub account_data:   pyth_sdk_solana::state::ProductAccount,
+    pub market_hours:   MarketHours,
     pub price_accounts: Vec<Pubkey>,
 }
 pub type PriceEntry = pyth_sdk_solana::state::PriceAccount;
@@ -134,7 +136,7 @@ pub fn spawn_oracle(
     wss_url: &str,
     rpc_timeout: Duration,
     global_store_update_tx: mpsc::Sender<global::Update>,
-    publisher_permissions_tx: mpsc::Sender<HashMap<Pubkey, HashSet<Pubkey>>>,
+    publisher_permissions_tx: mpsc::Sender<HashMap<Pubkey, HashMap<Pubkey, MarketHours>>>,
     key_store: KeyStore,
     logger: Logger,
 ) -> Vec<JoinHandle<()>> {
@@ -349,7 +351,7 @@ struct Poller {
     data_tx: mpsc::Sender<Data>,
 
     /// Updates about permissioned price accounts from oracle to exporter
-    publisher_permissions_tx: mpsc::Sender<HashMap<Pubkey, HashSet<Pubkey>>>,
+    publisher_permissions_tx: mpsc::Sender<HashMap<Pubkey, HashMap<Pubkey, MarketHours>>>,
 
     /// The RPC client to use to poll data from the RPC node
     rpc_client: RpcClient,
@@ -369,7 +371,7 @@ struct Poller {
 impl Poller {
     pub fn new(
         data_tx: mpsc::Sender<Data>,
-        publisher_permissions_tx: mpsc::Sender<HashMap<Pubkey, HashSet<Pubkey>>>,
+        publisher_permissions_tx: mpsc::Sender<HashMap<Pubkey, HashMap<Pubkey, MarketHours>>>,
         rpc_url: &str,
         rpc_timeout: Duration,
         commitment: CommitmentLevel,
@@ -435,9 +437,20 @@ impl Poller {
             for component in price_entry.comp {
                 let component_pub_entry = publisher_permissions
                     .entry(component.publisher)
-                    .or_insert(HashSet::new());
+                    .or_insert(HashMap::new());
 
-                component_pub_entry.insert(*price_key);
+                let market_hours = if let Some(prod_entry) = product_accounts.get(&price_entry.prod)
+                {
+                    prod_entry.market_hours.clone()
+                } else {
+                    warn!(&self.logger, "Oracle: INTERNAL: could not find product from price `prod` field, market hours falling back to 24/7.";
+                      "price" => price_key.to_string(),
+                      "missing_product" => price_entry.prod.to_string(),
+                    );
+                    Default::default()
+                };
+
+                component_pub_entry.insert(*price_key, market_hours);
             }
         }
 
@@ -525,10 +538,29 @@ impl Poller {
                 let product = load_product_account(prod_acc.data.as_slice())
                     .context(format!("Could not parse product account {}", product_key))?;
 
+                let market_hours: MarketHours = if let Some((_mh_key, mh_val)) =
+                    product.iter().find(|(k, _v)| *k == "market_hours")
+                {
+                    mh_val.parse().unwrap_or_else(|err| {
+			warn!(
+			    self.logger,
+			    "Oracle: Product has market_hours defined but it could not be parsed. Falling back to 24/7 publishing.";
+			    "product_key" => product_key.to_string(),
+			    "market_hours" => mh_val,
+				  );
+			debug!(self.logger, "parsing error context"; "context" => format!("{:?}", err));
+			Default::default()
+			}
+			)
+                } else {
+                    Default::default() // No market hours specified, meaning 24/7 publishing
+                };
+
                 product_entries.insert(
                     *product_key,
                     ProductEntry {
-                        account_data:   *product,
+                        account_data: *product,
+                        market_hours,
                         price_accounts: vec![],
                     },
                 );


### PR DESCRIPTION
# Motivation
This change builds on the previously introduced market hours format and applies it to the agent's publishing logic. The extraction, parsing and distribution of the market hours info piggy-backs the existing publisher permissions flow. This felt appropriate because of a shared idea: "Does on-chain data say this is okay to publish?". You'll quickly see that a big part of the changeset is a series of additions to the publisher permissions processing logic. In the same spirit, the changes to state simply add market hours to the detected permissioned symbols that are checked when filtering prices.

# Summary of changes
* `oracle.rs` - Attempt to parse market hours when looking up products, fall back to 24/7 if failing po parse. Specifically, print a warning if the market hours field is defined but could not be understood. Additionally, the market hours are passed together with permissioned prices in the existing channel going to exporter.
* `exporter.rs` - Use market hours data in price filtering.
* `market_hours.rs` - Add missing traits to please the compiler; make `can_publish_at` infallible (turns out the weekday extraction exists in `chrono` but it required some digging)
* `test_integration.py` - Add all-closed market hours to `AAPL_USD` and expect publishing to it to fail because of the market hours.

# Review Highlights
* The new metadata field is named "market_hours"
* The fallback behavior for market hours parsing problems is to use 24/7 market hours. In case we fatfinger the field on a symbol, it feels more appropriate to risk publishing it at a wrong time than to bring it down for all pubs when it's supposed to be up. I think it's important for us to agree about this.
* The point of reference for market hours is the OS system clock - I decided against using the solana clock since it is known to drift from time to time (there were incidents of sizable lag in the past on Solana's public networks)
* `test_integration.py` - the test is very rudimentary, using an all-closed market hours schedule, expecting the symbol to be unchanged. This is mostly due to agent using system clock to determine the current date/time. Fixturing the system clock feels unnecessary when dedicated edge case testing is available in the unit testsuite. The goal of the integration test is to verify that the code path successfully results in no publishing for the all-closed market hours. In case the symbol's hours data were to be misunderstood/lost, it would presumably fall back to a 24/7 schedule, exposing the problems along the code path. If you have good suggestions for making the test less trivial, it would be nice to discuss that.   