### PR TITLE
Drozdziak1/version bump and comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,7 +2835,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "2.3.1"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "2.3.1"
+version = "2.4.0"
 edition = "2021"
 
 [[bin]]

--- a/integration-tests/tests/test_integration.py
+++ b/integration-tests/tests/test_integration.py
@@ -756,11 +756,13 @@ class TestUpdatePrice(PythTest):
         await client.update_price(price_account, 42, 2, "trading")
         time.sleep(2)
 
-        # Send another "update_price" request to trigger aggregation
+        # Send another update_price request to "trigger" aggregation
+        # (aggregation would happen if market hours were to fail, but
+        # we want to catch that happening if there's a problem)
         await client.update_price(price_account, 81, 1, "trading")
         time.sleep(2)
 
-        # Confirm that the price account has been updated with the values from the first "update_price" request
+        # Confirm that the price account has not been updated
         final_product_state = await client.get_product(product_account)
 
         final_price_account = final_product_state["price_accounts"][0]


### PR DESCRIPTION
This small change bumps agent version to `2.4.0` for release and addresses a comment change nit that appeared in the market hours logic PR. 