### PR TITLE
fix: use both latest publisher and aggregate slot for dynamic pricing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "2.4.1"
+version = "2.4.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "2.4.1"
+version = "2.4.2"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
One publisher has tried the previous version. I noticed that often they fall behind on some specific symbols by not publishing themself and that causes a sudden increase in priority once they publish it. That is why i am also considering the aggregate slot for the pricing. I'm also excluding the non-live feeds because publishers are often more unstable on them.