### PR TITLE
refactor: improve price cap configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "2.4.2"
+version = "2.4.3"
 edition = "2021"
 
 [[bin]]

--- a/config/config.sample.pythnet.toml
+++ b/config/config.sample.pythnet.toml
@@ -58,15 +58,8 @@ exporter.compute_unit_limit = 20000
 # during periods of high network congestion.
 exporter.dynamic_compute_unit_pricing_enabled = true
 
-# Maximum slot gap between the current slot and the oldest slot amongst all the accounts in
-# the batch. This is used to calculate the dynamic price per compute unit. When the slot gap
-# reaches this number we will use the maximum total_compute_fee for the transaction.
-exporter.maximum_slot_gap_for_dynamic_compute_unit_price = 40
-
-# The interval with which to poll account information. We are adding it as an extra
-# layer of protection to ensure we get the latest account information if there are
-# any issues with the ws subscription.
-oracle.poll_interval_duration = "5s"
+# Price per compute unit offered for update_price transactions
+exporter.compute_unit_price_micro_lamports = 1000
 
 # Configuration for the JRPC API
 [pythd_adapter]

--- a/config/config.toml
+++ b/config/config.toml
@@ -83,10 +83,10 @@ key_store.mapping_key = "RelevantOracleMappingAddress"
 # calculated based on the network previous prioritization fees.
 # exporter.dynamic_compute_unit_pricing_enabled = false
 
-# Maximum total compute unit fee paid for a single transaction. Defaults to 0.001 SOL. This
-# is a safety measure while using dynamic compute price to prevent the exporter from paying
-# too much for a single transaction. The default is 10**12 micro lamports (0.001 SOL).
-# exporter.maximum_total_compute_fee_micro_lamports = 1000000000000
+# Maximum compute unit price offered for update_price transactions. Defaults to
+# 1 million microlamports. This is a safety measure while using dynamic compute
+# price to prevent the exporter from paying too much for a single transaction.
+# exporter.maximum_compute_unit_price_micro_lamports = 1000000
 
 # Maximum slot gap between the current slot and the oldest slot amongst all the accounts in
 # the batch. This is used to calculate the dynamic price per compute unit. When the slot gap

--- a/src/agent/solana/oracle.rs
+++ b/src/agent/solana/oracle.rs
@@ -121,7 +121,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             commitment:               CommitmentLevel::Confirmed,
-            poll_interval_duration:   Duration::from_secs(2 * 60),
+            poll_interval_duration:   Duration::from_secs(5),
             subscriber_enabled:       true,
             updates_channel_capacity: 10000,
             data_channel_capacity:    10000,


### PR DESCRIPTION
The old max cost for total transaction didn't make sense as everything is handled in the per compute unit pricing and in the grand scheme of things we care about the price of an update not a transaction (which can have between 1 to 12 updates). This will make the behaviour simpler. Also, there were cases where the tx had little updates and the per compute unit price went very high and it impacted other publishers.

This is a non-breaking change because the config reader ignores incorrect fields (I checked it).

The default cap is also changed to 10 million as there have been spikes up to 6 million in the past. If publishers have working ws + short pulls. For this reason I changed the default for pull duration to 5 seconds which can have bad impact on Pythnet but the network load is not that high.

I considered injecting slot data via websocket and polling to make sure the global data is up to date but there is no way to subscribe to latest confirmed slot and also relying on the context for the updates won't be useful (because if there is no update coming, we don't know whether it is a websocket problem or not any actual update).

After this rollout, we won't have massive sol burn incident anymore because we always halve the median of the minimum landed tx over the past slots (whereas previously we just used that value).