### PR TITLE
fix: fire and forget update tx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "2.4.3"
+version = "2.4.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "2.4.3"
+version = "2.4.4"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
The old behaviour causes the exporter not to publish prices regularly. This change spawns a separate thread to unblock the exporter loop on the rpc send_tx call. Also, because of the batch staggering behaviour to avoid calling rpc for all batches at the same time, the old approach would always resulted in waiting longer than the publishing period.