### PR TITLE
fix: remove unnecessary fresh price filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "2.4.4"
+version = "2.4.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "2.4.4"
+version = "2.4.5"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
This change removes a check in the code that does not allow multiple updates within the same timestamp (second based) pass through. `last_info.timestamp` is always less than or equal to `info.timestamp`. So, this condition `last_info.timestamp < info.timestamp` filters newer updates in the same timestamp and essentially caps our publishing frequency to 1s. It was intended to work for Solana but the publishing frequency itself takes care of it. This change might result in increased Sol burn but the action to reduce it should be reducing the frequency. Please note that in some filterings after, the same update prices are ignored so most of the fee savings should remain there.