### PR TITLE
Change notify price schedule interval duration from 400ms to 100ms

### DIFF
--- a/config/config.sample.pythnet.toml
+++ b/config/config.sample.pythnet.toml
@@ -67,4 +67,4 @@ exporter.compute_unit_price_micro_lamports = 1000
 # The duration of the interval at which `notify_price_sched` notifications will be sent.
 # Note that this doesn't affect the rate at which transactions are published:
 # this is soley a backwards-compatibility API feature.
-notify_price_sched_interval_duration = "400ms"
+notify_price_sched_interval_duration = "100ms"


### PR DESCRIPTION
In the agent code, there are different async actors. There is one actor for getting the prices from the publisher and there is another one to export what is already available to Pythnet/Solana. Some publishers continuously send their updates to agent and they have no problem. However, some publishers wait for a notification from the agent to send their update. The problem with having both at the same frequency is that there is a decent chance that these two intervals don't match with each other and cause occasions on which exporter doesn't have any data or skips one data and it increases the overall latency of our network. This PR changes the notification interval to 100ms to minimize the added latency.