### PR TITLE
add build-essential to dependencies install step in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Note that only permissioned publishers can publish data to the network. Please r
 Prerequisites: Rust 1.68 or higher. A Unix system is recommended.
 
 ```shell
-# Install dependencies
+# Install dependencies (Debian-based systems)
 $ apt install libssl-dev build-essential
 
 # Install Rust

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Note that only permissioned publishers can publish data to the network. Please r
 Prerequisites: Rust 1.68 or higher. A Unix system is recommended.
 
 ```shell
-# Install OpenSSL (Debian-based systems)
-$ apt install libssl-dev
+# Install dependencies
+$ apt install libssl-dev build-essential
 
 # Install Rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh


### PR DESCRIPTION
smol and arguably pedantic change. add build-essential installation to readme steps. rustup makes an assumption thats the C linker is already installed. on the fresh ubuntu 22.04 system i am building on build-essential wasn't installed leading to a `cc linker not found` error on rust compilation.

installing build-essential ensures the gcc tool chain is on the box.