### PR TITLE
fix: remove adapter <> api deadlock

### DIFF
--- a/src/agent/remote_keypair_loader.rs
+++ b/src/agent/remote_keypair_loader.rs
@@ -314,8 +314,7 @@ async fn handle_key_requests(
                 match response_tx.send(copied_keypair) {
                     Ok(()) => {}
                     Err(_e) => {
-                        warn!(logger, "remote_keypair_loader: Could not send back secondary keypair to channel";
-                        );
+                        warn!(logger, "remote_keypair_loader: Could not send back secondary keypair to channel");
                     }
                 }
             }

--- a/src/agent/solana/exporter.rs
+++ b/src/agent/solana/exporter.rs
@@ -462,7 +462,7 @@ impl Exporter {
         self.update_our_prices(&publish_keypair.pubkey());
 
         debug!(self.logger, "Exporter: filtering prices permissioned to us";
-               "our_prices" => format!("{:?}", self.our_prices),
+               "our_prices" => format!("{:?}", self.our_prices.keys()),
                "publish_pubkey" => publish_keypair.pubkey().to_string(),
         );
 
@@ -594,7 +594,6 @@ impl Exporter {
                     trace!(
                         self.logger,
                         "Exporter: No more permissioned price accounts in channel, using cached value";
-                        "cached_value" => format!("{:?}", self.our_prices),
                     );
                     break;
                 }


### PR DESCRIPTION
Adapter sends price update notifications to the subscriber API connection actor but at the same time the subscriber actor can get blcoked on receiving messages (e.g. product info) from Adapter. If the channel from Adapter to the subscriber gets full the Adapter can get blocked and this results in a deadlock. This situation propagates and queues messages in other actors and WS messages from the clients will grow in an unbounded queue that results in a constant memory growth (leak).

This change simply makes the Adaptor to subscriber API connection nonblocking by dropping messages if the channels are full.