### PR TITLE
fix: remove delay in publish_batch execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "2.5.0"
+version = "2.5.1"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
The existing code creates futures for publish_batch with delays to spread the rpc load evenly in the publish interval however due to the Rust async design those futures do not get started unless they are awaited. This results in additional deterministic latency of almost the publish_interval especially for the publishers who publish many prices.

This change removes the code as even the intended behaviour adds latency and disrupts the publish interval (the last publish_batch can block the actor loop).