### PR TITLE
chore: update Pythnet sample config

### DIFF
--- a/config/config.sample.pythnet.toml
+++ b/config/config.sample.pythnet.toml
@@ -69,4 +69,4 @@ exporter.maximum_compute_unit_price_micro_lamports = 100000
 # The duration of the interval at which `notify_price_sched` notifications will be sent.
 # Note that this doesn't affect the rate at which transactions are published:
 # this is soley a backwards-compatibility API feature.
-notify_price_sched_interval_duration = "100ms"
+notify_price_sched_interval_duration = "400ms"


### PR DESCRIPTION
100ms notify_sched_interval is causing problems for the publishers and this change reverts it back to 400ms.

The exact reason for the problem is still unknown but we think their slow clients (forked from our example publisher) and poor agent design cause this issue. A major refactor is going to improve agent bottlenecks and also remove notifications  to make sure it doesn't add unnecessary overhead to the clients.