### PR TITLE
Send publisher permissions using a watch channel to address heap growth

### DIFF
--- a/src/agent/solana.rs
+++ b/src/agent/solana.rs
@@ -8,9 +8,9 @@ pub mod network {
 
     use {
         super::{
-            super::{
-                store,
-                store::global,
+            super::store::{
+                self,
+                global,
             },
             exporter,
             key_store::{
@@ -29,8 +29,8 @@ pub mod network {
         std::time::Duration,
         tokio::{
             sync::{
-                mpsc,
                 mpsc::Sender,
+                watch,
             },
             task::JoinHandle,
         },
@@ -86,8 +86,7 @@ pub mod network {
         logger: Logger,
     ) -> Result<Vec<JoinHandle<()>>> {
         // Publisher permissions updates between oracle and exporter
-        let (publisher_permissions_tx, publisher_permissions_rx) =
-            mpsc::channel(config.oracle.updates_channel_capacity);
+        let (publisher_permissions_tx, publisher_permissions_rx) = watch::channel(<_>::default());
 
         // Spawn the Oracle
         let mut jhs = oracle::spawn_oracle(


### PR DESCRIPTION
Fixes heap growth if `Exporter::update_our_prices` is not called as often as updates. 

Running `agent --config config/config.sample.pythtest.toml` would previously appear to "leak" memory quite quickly over time as `Exporter::update_our_prices` was not being called to drain the channel. The existing publisher permissions is bounded, but bounded at 10k would take a long time to fill and has a huge memory ceiling.

The fix is straightforward as the receiver side only ever used the latest value sent anyway, replacing the mpsc bounded channel with a watch channel produces equivalent behaviour but with a drastically reduced memory ceiling as it holds a single clone of the `publisher_permissions` map no matter the behaviour/frequency of the rx side.