### PR TITLE
chore: update max compute unit config and bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3270,7 +3270,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "2.6.1"
+version = "2.6.2"
 edition = "2021"
 
 [[bin]]

--- a/config/config.toml
+++ b/config/config.toml
@@ -74,7 +74,7 @@ key_store.mapping_key = "RelevantOracleMappingAddress"
 # exporter.max_batch_size = 12
 
 # Number of compute units requested per update_price instruction within the transaction.
-# exporter.compute_unit_limit = 20000
+# exporter.compute_unit_limit = 60000
 
 # Price per compute unit offered for update_price transactions
 # exporter.compute_unit_price_micro_lamports =

--- a/src/agent/solana/exporter.rs
+++ b/src/agent/solana/exporter.rs
@@ -153,8 +153,10 @@ impl Default for Config {
             max_batch_size:                                  12,
             inflight_transactions_channel_capacity:          10000,
             transaction_monitor:                             Default::default(),
-            // The largest transactions appear to be about ~12000 CUs. We leave ourselves some breathing room.
-            compute_unit_limit:                              40000,
+            // The largest transactions without accumulator spend around 38k compute units
+            // and accumulator cpi costs around 10k compute units. We set the limit to 60k
+            // to have some buffer.
+            compute_unit_limit:                              60000,
             compute_unit_price_micro_lamports:               None,
             dynamic_compute_unit_pricing_enabled:            false,
             // Maximum compute unit price (as a cap on the dynamic price)


### PR DESCRIPTION
This change updates the CU limit to make sure that price updates with more than 32 publishers have enough CU. Number 38k is obtained based on adjusting `test_full_publisher_set` test on the oracle to run in multiple rounds with random price updates to make sure worst case sorting is reached. Unfortunately there was no way to test it with CPI to accumulator (message buffer) and that number is taken based on current tx usage and the extra buffer is there because there are some extra logic in the oracle for oracle as well and the CU limit is not applied in transaction scheduling.