### PR TITLE
feat: add publish_interval logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3270,7 +3270,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "2.6.2"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "2.6.2"
+version = "2.7.0"
 edition = "2021"
 
 [[bin]]

--- a/src/agent/dashboard.rs
+++ b/src/agent/dashboard.rs
@@ -102,11 +102,7 @@ impl MetricsServer {
                 };
 
                 let last_local_update_string = if let Some(local_data) = price_data.local_data {
-                    if let Some(datetime) = DateTime::from_timestamp(local_data.timestamp, 0) {
-                        datetime.format("%Y-%m-%d %H:%M:%S").to_string()
-                    } else {
-                        format!("Invalid timestamp {}", local_data.timestamp)
-                    }
+                    local_data.timestamp.format("%Y-%m-%d %H:%M:%S").to_string()
                 } else {
                     "no data".to_string()
                 };

--- a/src/agent/metrics.rs
+++ b/src/agent/metrics.rs
@@ -40,9 +40,7 @@ use {
     },
     warp::{
         hyper::StatusCode,
-        reply::{
-            self,
-        },
+        reply,
         Filter,
         Rejection,
         Reply,
@@ -428,7 +426,7 @@ impl PriceLocalMetrics {
             .get_or_create(&PriceLocalLabels {
                 pubkey: price_key.to_string(),
             })
-            .set(price_info.timestamp);
+            .set(price_info.timestamp.and_utc().timestamp());
         update_count
             .get_or_create(&PriceLocalLabels {
                 pubkey: price_key.to_string(),

--- a/src/agent/pythd/adapter.rs
+++ b/src/agent/pythd/adapter.rs
@@ -462,7 +462,7 @@ mod tests {
                     )
                     .unwrap(),
                     solana::oracle::ProductEntry {
-                        account_data:   pyth_sdk_solana::state::ProductAccount {
+                        account_data:     pyth_sdk_solana::state::ProductAccount {
                             magic:  0xa1b2c3d4,
                             ver:    6,
                             atype:  4,
@@ -499,8 +499,9 @@ mod tests {
                                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                             ],
                         },
-                        schedule:       Default::default(),
-                        price_accounts: vec![
+                        schedule:         Default::default(),
+                        publish_interval: None,
+                        price_accounts:   vec![
                             solana_sdk::pubkey::Pubkey::from_str(
                                 "GVXRSBjFk6e6J3NbVPXohDJetcTjaeeuykUpbQF8UoMU",
                             )
@@ -522,7 +523,7 @@ mod tests {
                     )
                     .unwrap(),
                     solana::oracle::ProductEntry {
-                        account_data:   pyth_sdk_solana::state::ProductAccount {
+                        account_data:     pyth_sdk_solana::state::ProductAccount {
                             magic:  0xa1b2c3d4,
                             ver:    5,
                             atype:  3,
@@ -559,8 +560,9 @@ mod tests {
                                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                             ],
                         },
-                        schedule:       Default::default(),
-                        price_accounts: vec![
+                        schedule:         Default::default(),
+                        publish_interval: None,
+                        price_accounts:   vec![
                             solana_sdk::pubkey::Pubkey::from_str(
                                 "GG3FTE7xhc9Diy7dn9P6BWzoCrAEE4D3p5NBYrDAm5DD",
                             )

--- a/src/agent/pythd/adapter/api.rs
+++ b/src/agent/pythd/adapter/api.rs
@@ -375,7 +375,7 @@ impl AdapterApi for Adapter {
                     status: Adapter::map_status(&status)?,
                     price,
                     conf,
-                    timestamp: Utc::now().timestamp(),
+                    timestamp: Utc::now().naive_utc(),
                 },
             })
             .await

--- a/src/agent/solana/exporter.rs
+++ b/src/agent/solana/exporter.rs
@@ -8,6 +8,7 @@ use {
         },
         key_store,
         network::Network,
+        oracle::PublisherPermission,
     },
     crate::agent::{
         market_schedule::MarketSchedule,
@@ -174,7 +175,9 @@ pub fn spawn_exporter(
     network: Network,
     rpc_url: &str,
     rpc_timeout: Duration,
-    publisher_permissions_rx: watch::Receiver<HashMap<Pubkey, HashMap<Pubkey, MarketSchedule>>>,
+    publisher_permissions_rx: watch::Receiver<
+        HashMap<Pubkey, HashMap<Pubkey, PublisherPermission>>,
+    >,
     key_store: KeyStore,
     local_store_tx: Sender<store::local::Message>,
     global_store_tx: Sender<store::global::Lookup>,
@@ -262,10 +265,11 @@ pub struct Exporter {
     inflight_transactions_tx: Sender<Signature>,
 
     /// publisher => { permissioned_price => market hours } as read by the oracle module
-    publisher_permissions_rx: watch::Receiver<HashMap<Pubkey, HashMap<Pubkey, MarketSchedule>>>,
+    publisher_permissions_rx:
+        watch::Receiver<HashMap<Pubkey, HashMap<Pubkey, PublisherPermission>>>,
 
     /// Currently known permissioned prices of this publisher along with their market hours
-    our_prices: HashMap<Pubkey, MarketSchedule>,
+    our_prices: HashMap<Pubkey, PublisherPermission>,
 
     /// Interval to update the dynamic price (if enabled)
     dynamic_compute_unit_price_update_interval: Interval,
@@ -289,7 +293,9 @@ impl Exporter {
         global_store_tx: Sender<store::global::Lookup>,
         network_state_rx: watch::Receiver<NetworkState>,
         inflight_transactions_tx: Sender<Signature>,
-        publisher_permissions_rx: watch::Receiver<HashMap<Pubkey, HashMap<Pubkey, MarketSchedule>>>,
+        publisher_permissions_rx: watch::Receiver<
+            HashMap<Pubkey, HashMap<Pubkey, PublisherPermission>>,
+        >,
         keypair_request_tx: mpsc::Sender<KeypairRequest>,
         logger: Logger,
     ) -> Self {
@@ -432,15 +438,23 @@ impl Exporter {
     async fn get_permissioned_updates(&mut self) -> Result<Vec<(PriceIdentifier, PriceInfo)>> {
         let local_store_contents = self.fetch_local_store_contents().await?;
 
-        let now = Utc::now().timestamp();
+        let publish_keypair = self.get_publish_keypair().await?;
+        self.update_our_prices(&publish_keypair.pubkey());
+
+        let now = Utc::now();
+
+        debug!(self.logger, "Exporter: filtering prices permissioned to us";
+               "our_prices" => format!("{:?}", self.our_prices.keys()),
+               "publish_pubkey" => publish_keypair.pubkey().to_string(),
+        );
 
         // Filter the contents to only include information we haven't already sent,
         // and to ignore stale information.
-        let fresh_updates = local_store_contents
+        Ok(local_store_contents
             .into_iter()
             .filter(|(_identifier, info)| {
                 // Filter out timestamps that are old
-                (now - info.timestamp) < self.config.staleness_threshold.as_secs() as i64
+                (now.timestamp() - info.timestamp) < self.config.staleness_threshold.as_secs() as i64
             })
             .filter(|(identifier, info)| {
                 // Filter out unchanged price data if the max delay wasn't reached
@@ -457,32 +471,15 @@ impl Exporter {
                     true // No prior data found, letting the price through
                 }
             })
-            .collect::<Vec<_>>();
-
-        let publish_keypair = self.get_publish_keypair().await?;
-
-        self.update_our_prices(&publish_keypair.pubkey());
-
-        debug!(self.logger, "Exporter: filtering prices permissioned to us";
-               "our_prices" => format!("{:?}", self.our_prices.keys()),
-               "publish_pubkey" => publish_keypair.pubkey().to_string(),
-        );
-
-        // Get a fresh system time
-        let now = Utc::now();
-
-        // Filter out price accounts we're not permissioned to update
-        Ok(fresh_updates
-            .into_iter()
             .filter(|(id, _data)| {
                 let key_from_id = Pubkey::from((*id).clone().to_bytes());
-                if let Some(schedule) = self.our_prices.get(&key_from_id) {
-                    let ret = schedule.can_publish_at(&now);
+                if let Some(publisher_permission) = self.our_prices.get(&key_from_id) {
+                    let ret = publisher_permission.schedule.can_publish_at(&now);
 
                     if !ret {
                         debug!(self.logger, "Exporter: Attempted to publish price outside market hours";
                             "price_account" => key_from_id.to_string(),
-                            "schedule" => format!("{:?}", schedule),
+                            "schedule" => format!("{:?}", publisher_permission.schedule),
                             "utc_time" => now.format("%c").to_string(),
                         );
                     }
@@ -500,6 +497,31 @@ impl Exporter {
                     );
                     false
                 }
+            })
+            .filter(|(id, info)| {
+                // Filtering out prices that are being updated too frequently according to publisher_permission.publish_interval
+                let last_info = self.last_published_state.get(id);
+                if last_info.is_none() {
+                    // No prior data found, letting the price through
+                    return true;
+                }
+                let last_info = last_info.unwrap();
+
+                let key_from_id = Pubkey::from((*id).clone().to_bytes());
+                let publisher_permisssion = self.our_prices.get(&key_from_id);
+                if publisher_permisssion.is_none() {
+                    // Should never happen since we have filtered out the price above
+                    return false;
+                }
+                let publisher_permission = publisher_permisssion.unwrap();
+
+                if let Some(publish_interval) = publisher_permission.publish_interval {
+                    if info.timestamp.saturating_sub(last_info.timestamp) < publish_interval.as_secs() as i64 {
+                        // Updating the price too soon after the last update, skipping
+                        return false;
+                    }
+                }
+                true
             })
             .collect::<Vec<_>>())
     }

--- a/src/agent/solana/exporter.rs
+++ b/src/agent/solana/exporter.rs
@@ -8,15 +8,12 @@ use {
         },
         key_store,
         network::Network,
-        oracle::PublisherPermission,
+        oracle::PricePublishingMetadata,
     },
-    crate::agent::{
-        market_schedule::MarketSchedule,
-        remote_keypair_loader::{
+    crate::agent::remote_keypair_loader::{
             KeypairRequest,
             RemoteKeypairLoader,
         },
-    },
     anyhow::{
         anyhow,
         Context,
@@ -176,7 +173,7 @@ pub fn spawn_exporter(
     rpc_url: &str,
     rpc_timeout: Duration,
     publisher_permissions_rx: watch::Receiver<
-        HashMap<Pubkey, HashMap<Pubkey, PublisherPermission>>,
+        HashMap<Pubkey, HashMap<Pubkey, PricePublishingMetadata>>,
     >,
     key_store: KeyStore,
     local_store_tx: Sender<store::local::Message>,
@@ -266,10 +263,10 @@ pub struct Exporter {
 
     /// publisher => { permissioned_price => market hours } as read by the oracle module
     publisher_permissions_rx:
-        watch::Receiver<HashMap<Pubkey, HashMap<Pubkey, PublisherPermission>>>,
+        watch::Receiver<HashMap<Pubkey, HashMap<Pubkey, PricePublishingMetadata>>>,
 
     /// Currently known permissioned prices of this publisher along with their market hours
-    our_prices: HashMap<Pubkey, PublisherPermission>,
+    our_prices: HashMap<Pubkey, PricePublishingMetadata>,
 
     /// Interval to update the dynamic price (if enabled)
     dynamic_compute_unit_price_update_interval: Interval,
@@ -294,7 +291,7 @@ impl Exporter {
         network_state_rx: watch::Receiver<NetworkState>,
         inflight_transactions_tx: Sender<Signature>,
         publisher_permissions_rx: watch::Receiver<
-            HashMap<Pubkey, HashMap<Pubkey, PublisherPermission>>,
+            HashMap<Pubkey, HashMap<Pubkey, PricePublishingMetadata>>,
         >,
         keypair_request_tx: mpsc::Sender<KeypairRequest>,
         logger: Logger,

--- a/src/agent/solana/exporter.rs
+++ b/src/agent/solana/exporter.rs
@@ -11,9 +11,9 @@ use {
         oracle::PricePublishingMetadata,
     },
     crate::agent::remote_keypair_loader::{
-            KeypairRequest,
-            RemoteKeypairLoader,
-        },
+        KeypairRequest,
+        RemoteKeypairLoader,
+    },
     anyhow::{
         anyhow,
         Context,
@@ -66,7 +66,6 @@ use {
         sync::{
             mpsc::{
                 self,
-                error::TryRecvError,
                 Sender,
             },
             oneshot,

--- a/src/agent/solana/oracle.rs
+++ b/src/agent/solana/oracle.rs
@@ -116,12 +116,18 @@ impl std::ops::Deref for PriceEntry {
 }
 
 #[derive(Default, Debug, Clone)]
+pub struct PublisherPermission {
+    pub schedule:         MarketSchedule,
+    pub publish_interval: Option<Duration>,
+}
+
+#[derive(Default, Debug, Clone)]
 pub struct Data {
     pub mapping_accounts:      HashMap<Pubkey, MappingAccount>,
     pub product_accounts:      HashMap<Pubkey, ProductEntry>,
     pub price_accounts:        HashMap<Pubkey, PriceEntry>,
     /// publisher => {their permissioned price accounts => market hours}
-    pub publisher_permissions: HashMap<Pubkey, HashMap<Pubkey, MarketSchedule>>,
+    pub publisher_permissions: HashMap<Pubkey, HashMap<Pubkey, PublisherPermission>>,
 }
 
 impl Data {
@@ -129,7 +135,7 @@ impl Data {
         mapping_accounts: HashMap<Pubkey, MappingAccount>,
         product_accounts: HashMap<Pubkey, ProductEntry>,
         price_accounts: HashMap<Pubkey, PriceEntry>,
-        publisher_permissions: HashMap<Pubkey, HashMap<Pubkey, MarketSchedule>>,
+        publisher_permissions: HashMap<Pubkey, HashMap<Pubkey, PublisherPermission>>,
     ) -> Self {
         Data {
             mapping_accounts,
@@ -143,9 +149,10 @@ impl Data {
 pub type MappingAccount = pyth_sdk_solana::state::MappingAccount;
 #[derive(Debug, Clone)]
 pub struct ProductEntry {
-    pub account_data:   pyth_sdk_solana::state::ProductAccount,
-    pub schedule:       MarketSchedule,
-    pub price_accounts: Vec<Pubkey>,
+    pub account_data:     pyth_sdk_solana::state::ProductAccount,
+    pub schedule:         MarketSchedule,
+    pub price_accounts:   Vec<Pubkey>,
+    pub publish_interval: Option<Duration>,
 }
 
 // Oracle is responsible for fetching Solana account data stored in the Pyth on-chain Oracle.
@@ -207,7 +214,7 @@ pub fn spawn_oracle(
     wss_url: &str,
     rpc_timeout: Duration,
     global_store_update_tx: mpsc::Sender<global::Update>,
-    publisher_permissions_tx: watch::Sender<HashMap<Pubkey, HashMap<Pubkey, MarketSchedule>>>,
+    publisher_permissions_tx: watch::Sender<HashMap<Pubkey, HashMap<Pubkey, PublisherPermission>>>,
     key_store: KeyStore,
     logger: Logger,
 ) -> Vec<JoinHandle<()>> {
@@ -422,7 +429,7 @@ struct Poller {
     data_tx: mpsc::Sender<Data>,
 
     /// Updates about permissioned price accounts from oracle to exporter
-    publisher_permissions_tx: watch::Sender<HashMap<Pubkey, HashMap<Pubkey, MarketSchedule>>>,
+    publisher_permissions_tx: watch::Sender<HashMap<Pubkey, HashMap<Pubkey, PublisherPermission>>>,
 
     /// The RPC client to use to poll data from the RPC node
     rpc_client: RpcClient,
@@ -442,7 +449,9 @@ struct Poller {
 impl Poller {
     pub fn new(
         data_tx: mpsc::Sender<Data>,
-        publisher_permissions_tx: watch::Sender<HashMap<Pubkey, HashMap<Pubkey, MarketSchedule>>>,
+        publisher_permissions_tx: watch::Sender<
+            HashMap<Pubkey, HashMap<Pubkey, PublisherPermission>>,
+        >,
         rpc_url: &str,
         rpc_timeout: Duration,
         commitment: CommitmentLevel,
@@ -483,6 +492,7 @@ impl Poller {
     async fn poll_and_send(&mut self) -> Result<()> {
         let fresh_data = self.poll().await?;
 
+
         self.publisher_permissions_tx
             .send_replace(fresh_data.publisher_permissions.clone());
 
@@ -512,8 +522,13 @@ impl Poller {
                     .entry(component.publisher)
                     .or_insert(HashMap::new());
 
-                let schedule = if let Some(prod_entry) = product_accounts.get(&price_entry.prod) {
-                    prod_entry.schedule.clone()
+                let publisher_permission = if let Some(prod_entry) =
+                    product_accounts.get(&price_entry.prod)
+                {
+                    PublisherPermission {
+                        schedule:         prod_entry.schedule.clone(),
+                        publish_interval: prod_entry.publish_interval.clone(),
+                    }
                 } else {
                     warn!(&self.logger, "Oracle: INTERNAL: could not find product from price `prod` field, market hours falling back to 24/7.";
                       "price" => price_key.to_string(),
@@ -522,7 +537,7 @@ impl Poller {
                     Default::default()
                 };
 
-                component_pub_entry.insert(*price_key, schedule);
+                component_pub_entry.insert(*price_key, publisher_permission);
             }
         }
 
@@ -650,12 +665,36 @@ impl Poller {
                     None
                 };
 
+                let publish_interval: Option<Duration> = if let Some((
+                    _publish_interval_key,
+                    publish_interval_val,
+                )) =
+                    product.iter().find(|(k, _v)| *k == "publish_interval")
+                {
+                    match publish_interval_val.parse::<f64>() {
+                        Ok(interval) => Some(Duration::from_secs_f64(interval)),
+                        Err(err) => {
+                            warn!(
+                                self.logger,
+                                "Oracle: Product has publish_interval defined but it could not be parsed. Falling back to None.";
+                                "product_key" => product_key.to_string(),
+                                "publish_interval" => publish_interval_val,
+                            );
+                            debug!(self.logger, "parsing error context"; "context" => format!("{:?}", err));
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+
                 product_entries.insert(
                     *product_key,
                     ProductEntry {
-                        account_data:   *product,
-                        schedule:       market_schedule.unwrap_or_else(|| legacy_schedule.into()),
+                        account_data: *product,
+                        schedule: market_schedule.unwrap_or_else(|| legacy_schedule.into()),
                         price_accounts: vec![],
+                        publish_interval,
                     },
                 );
             } else {

--- a/src/agent/solana/oracle.rs
+++ b/src/agent/solana/oracle.rs
@@ -214,7 +214,9 @@ pub fn spawn_oracle(
     wss_url: &str,
     rpc_timeout: Duration,
     global_store_update_tx: mpsc::Sender<global::Update>,
-    publisher_permissions_tx: watch::Sender<HashMap<Pubkey, HashMap<Pubkey, PricePublishingMetadata>>>,
+    publisher_permissions_tx: watch::Sender<
+        HashMap<Pubkey, HashMap<Pubkey, PricePublishingMetadata>>,
+    >,
     key_store: KeyStore,
     logger: Logger,
 ) -> Vec<JoinHandle<()>> {
@@ -429,7 +431,8 @@ struct Poller {
     data_tx: mpsc::Sender<Data>,
 
     /// Updates about permissioned price accounts from oracle to exporter
-    publisher_permissions_tx: watch::Sender<HashMap<Pubkey, HashMap<Pubkey, PricePublishingMetadata>>>,
+    publisher_permissions_tx:
+        watch::Sender<HashMap<Pubkey, HashMap<Pubkey, PricePublishingMetadata>>>,
 
     /// The RPC client to use to poll data from the RPC node
     rpc_client: RpcClient,

--- a/src/agent/store/local.rs
+++ b/src/agent/store/local.rs
@@ -11,7 +11,7 @@ use {
         anyhow,
         Result,
     },
-    pyth_sdk::UnixTimestamp,
+    chrono::NaiveDateTime,
     pyth_sdk_solana::state::PriceStatus,
     slog::Logger,
     solana_sdk::bs58,
@@ -30,7 +30,7 @@ pub struct PriceInfo {
     pub status:    PriceStatus,
     pub price:     i64,
     pub conf:      u64,
-    pub timestamp: UnixTimestamp,
+    pub timestamp: NaiveDateTime,
 }
 
 impl PriceInfo {


### PR DESCRIPTION
This PR introduces support for a new product metadata key `publish_interval`. It will only allow the publish of a new price after this interval has passed since last updated price.