### PR TITLE
refactor(agent): add tracing to expensive calls

### DIFF
--- a/src/agent/pyth/rpc.rs
+++ b/src/agent/pyth/rpc.rs
@@ -50,6 +50,7 @@ use {
         sync::Arc,
     },
     tokio::sync::mpsc,
+    tracing::instrument,
     warp::{
         ws::{
             Message,
@@ -411,6 +412,7 @@ impl Default for Config {
     }
 }
 
+#[instrument(skip_all)]
 pub async fn run<S>(config: Config, state: Arc<S>)
 where
     S: state::Prices,

--- a/src/agent/pyth/rpc/update_price.rs
+++ b/src/agent/pyth/rpc/update_price.rs
@@ -12,8 +12,10 @@ use {
         Request,
         Value,
     },
+    tracing::instrument,
 };
 
+#[instrument(skip_all, fields(account))]
 pub async fn update_price<S>(
     state: &S,
     request: &Request<Method, Value>,
@@ -27,6 +29,8 @@ where
             .clone()
             .ok_or_else(|| anyhow!("Missing request parameters"))?,
     )?;
+
+    tracing::Span::current().record("account", params.account.to_string());
 
     state
         .update_local_price(

--- a/src/agent/services/notifier.rs
+++ b/src/agent/services/notifier.rs
@@ -6,8 +6,10 @@
 use {
     crate::agent::state::Prices,
     std::sync::Arc,
+    tracing::instrument,
 };
 
+#[instrument(skip(state))]
 pub async fn notifier<S>(state: Arc<S>)
 where
     S: Prices,

--- a/src/agent/state/api.rs
+++ b/src/agent/state/api.rs
@@ -53,6 +53,7 @@ use {
         mpsc,
         RwLock,
     },
+    tracing::instrument,
 };
 
 // TODO: implement Display on PriceStatus and then just call PriceStatus::to_string
@@ -382,6 +383,10 @@ where
         .map_err(|_| anyhow!("failed to send update to local store"))
     }
 
+    #[instrument(skip(self, update), fields(update = match update {
+        Update::ProductAccountUpdate { account_key, .. } => account_key,
+        Update::PriceAccountUpdate   { account_key, .. } => account_key,
+    }.to_string()))]
     async fn update_global_price(&self, network: Network, update: &Update) -> Result<()> {
         GlobalStore::update(self, network, update)
             .await

--- a/src/agent/state/keypairs.rs
+++ b/src/agent/state/keypairs.rs
@@ -8,6 +8,7 @@ use {
     anyhow::Result,
     solana_sdk::signature::Keypair,
     tokio::sync::RwLock,
+    tracing::instrument,
 };
 
 #[derive(Default)]
@@ -35,6 +36,7 @@ where
     for<'a> &'a T: Into<&'a KeypairState>,
     T: Sync,
 {
+    #[instrument(skip(self))]
     async fn request_keypair(&self, network: Network) -> Result<Keypair> {
         let keypair = match network {
             Network::Primary => &self.into().primary_current_keypair,
@@ -51,6 +53,7 @@ where
         )?)
     }
 
+    #[instrument(skip(self))]
     async fn update_keypair(&self, network: Network, new_keypair: Keypair) {
         *match network {
             Network::Primary => self.into().primary_current_keypair.write().await,

--- a/src/agent/state/oracle.rs
+++ b/src/agent/state/oracle.rs
@@ -46,6 +46,7 @@ use {
         time::Duration,
     },
     tokio::sync::RwLock,
+    tracing::instrument,
 };
 
 #[derive(Debug, Clone)]
@@ -96,6 +97,7 @@ impl From<SolanaPriceAccount> for PriceEntry {
 
 impl PriceEntry {
     /// Construct the right underlying GenericPriceAccount based on the account size.
+    #[instrument(skip(acc))]
     pub fn load_from_account(acc: &[u8]) -> Option<Self> {
         unsafe {
             let size = match acc.len() {
@@ -216,6 +218,7 @@ where
     T: Prices,
     T: Exporter,
 {
+    #[instrument(skip(self, account_key))]
     async fn handle_price_account_update(
         &self,
         network: Network,
@@ -259,6 +262,7 @@ where
     }
 
     /// Poll target Solana based chain for Pyth related accounts.
+    #[instrument(skip(self, rpc_client))]
     async fn poll_updates(
         &self,
         network: Network,
@@ -329,6 +333,7 @@ where
     }
 
     /// Sync Product/Price Accounts found by polling to the Global Store.
+    #[instrument(skip(self))]
     async fn sync_global_store(&self, network: Network) -> Result<()> {
         for (product_account_key, product_account) in
             &self.into().data.read().await.product_accounts
@@ -362,6 +367,7 @@ where
     }
 }
 
+#[instrument(skip(rpc_client))]
 async fn fetch_mapping_accounts(
     rpc_client: &RpcClient,
     mapping_account_key: Pubkey,
@@ -381,6 +387,7 @@ async fn fetch_mapping_accounts(
     Ok(accounts)
 }
 
+#[instrument(skip(rpc_client, mapping_accounts))]
 async fn fetch_product_and_price_accounts<'a, A>(
     rpc_client: &RpcClient,
     max_lookup_batch_size: usize,

--- a/src/agent/state/transactions.rs
+++ b/src/agent/state/transactions.rs
@@ -8,6 +8,7 @@ use {
     },
     std::collections::VecDeque,
     tokio::sync::RwLock,
+    tracing::instrument,
 };
 
 #[derive(Default)]
@@ -44,6 +45,7 @@ where
     for<'a> &'a T: Into<&'a TransactionsState>,
     T: Sync + Send + 'static,
 {
+    #[instrument(skip(self))]
     async fn add_transaction(&self, signature: Signature) {
         tracing::debug!(
             signature = signature.to_string(),
@@ -60,6 +62,7 @@ where
         }
     }
 
+    #[instrument(skip(self, rpc))]
     async fn poll_transactions_status(&self, rpc: &RpcClient) -> Result<()> {
         let mut txs = self.into().sent_transactions.write().await;
         if txs.is_empty() {


### PR DESCRIPTION
Adds some initial tracing to the new refactored version of the agent based on API method calls. The update_price RPC call emits a trace log with an account key, and the batch function is similarly emitting keys, so it should now be possible  to measure the time difference between an update entering the program and being submitted.