### PR TITLE
improve tracing coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +482,51 @@ name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+
+[[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "backtrace"
@@ -1793,6 +1860,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "goblin"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2056,6 +2129,18 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -2407,6 +2492,12 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
@@ -2767,6 +2858,81 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "opentelemetry"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94c69209c05319cdf7460c6d4c055ed102be242a0a6245835d7bc42c6ec7f54"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984806e6cf27f2b49282e2a05e288f30594f3dbc74eb7a6e99422bc48ed78162"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae312d58eaa90a82d2e627fd86e075cf5230b3f11794e2ed74199ebbe572d4fd"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "lazy_static",
+ "once_cell",
+ "opentelemetry",
+ "ordered-float",
+ "percent-encoding",
+ "rand 0.8.5",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ff2cf528c6c03d9ed653d6c4ce1dc0582dc4af309790ad92f07c1cd551b0be"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ordered-multimap"
@@ -3210,6 +3376,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "pyth-agent"
 version = "2.9.0"
 dependencies = [
@@ -3227,6 +3416,9 @@ dependencies = [
  "iobuffer",
  "jrpc",
  "lazy_static",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "parking_lot",
  "portpicker",
  "prometheus-client",
@@ -3248,6 +3440,7 @@ dependencies = [
  "tokio-util",
  "toml_edit 0.22.9",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "typed-html",
  "warp",
@@ -5566,6 +5759,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5707,6 +5910,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.7",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5754,6 +6010,24 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f68803492bf28ab40aeccaecc7021096bd256baf7ca77c3d425d89b35a7be4e4"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -6136,6 +6410,16 @@ name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "2.9.0"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,10 @@ winnow = "0.6.5"
 proptest = "1.4.0"
 tracing = { version = "0.1.40", features = ["log"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
+tracing-opentelemetry = "0.24.0"
+opentelemetry = "0.23.0"
+opentelemetry_sdk = { version = "0.23.0", features = ["rt-tokio"]}
+opentelemetry-otlp = { version = "0.16.0" }
 
 [dev-dependencies]
 tokio-util = { version = "0.7.10", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "2.9.0"
+version = "2.10.0"
 edition = "2021"
 
 [[bin]]

--- a/config/config.sample.pythnet.toml
+++ b/config/config.sample.pythnet.toml
@@ -70,12 +70,3 @@ exporter.maximum_compute_unit_price_micro_lamports = 100000
 # Note that this doesn't affect the rate at which transactions are published:
 # this is soley a backwards-compatibility API feature.
 notify_price_sched_interval_duration = "400ms"
-
-# Configuration for OpenTelemetry
-[opentelemetry]
-
-# Timeout in seconds for the OpenTelemetry exporter
-exporter_timeout_secs = 3
-
-# Endpoint URL for the OpenTelemetry exporter
-exporter_endpoint = "http://127.0.0.1:4317"

--- a/config/config.sample.pythnet.toml
+++ b/config/config.sample.pythnet.toml
@@ -70,3 +70,12 @@ exporter.maximum_compute_unit_price_micro_lamports = 100000
 # Note that this doesn't affect the rate at which transactions are published:
 # this is soley a backwards-compatibility API feature.
 notify_price_sched_interval_duration = "400ms"
+
+# Configuration for OpenTelemetry
+[opentelemetry]
+
+# Timeout in seconds for the OpenTelemetry exporter
+exporter_timeout_secs = 3
+
+# Endpoint URL for the OpenTelemetry exporter
+exporter_endpoint = "http://127.0.0.1:4317"

--- a/config/config.sample.pythtest.toml
+++ b/config/config.sample.pythtest.toml
@@ -60,3 +60,12 @@ exporter.compute_unit_price_micro_lamports = 1000
 # Note that this doesn't affect the rate at which transactions are published:
 # this is soley a backwards-compatibility API feature.
 notify_price_sched_interval_duration = "400ms"
+
+# Configuration for OpenTelemetry
+[opentelemetry]
+
+# Timeout in seconds for the OpenTelemetry exporter
+exporter_timeout_secs = 3
+
+# Endpoint URL for the OpenTelemetry exporter
+exporter_endpoint = "http://127.0.0.1:4317"

--- a/config/config.sample.pythtest.toml
+++ b/config/config.sample.pythtest.toml
@@ -60,12 +60,3 @@ exporter.compute_unit_price_micro_lamports = 1000
 # Note that this doesn't affect the rate at which transactions are published:
 # this is soley a backwards-compatibility API feature.
 notify_price_sched_interval_duration = "400ms"
-
-# Configuration for OpenTelemetry
-[opentelemetry]
-
-# Timeout in seconds for the OpenTelemetry exporter
-exporter_timeout_secs = 3
-
-# Endpoint URL for the OpenTelemetry exporter
-exporter_endpoint = "http://127.0.0.1:4317"

--- a/config/config.toml
+++ b/config/config.toml
@@ -181,3 +181,13 @@ key_store.mapping_key = "RelevantOracleMappingAddress"
 # publish data to. In most cases this should be a Solana endpoint. The
 # options correspond to the ones in primary_network
 # [secondary_network]
+
+
+## Configuration for OpenTelemetry ##
+[opentelemetry]
+
+# Timeout in seconds for the OpenTelemetry exporter
+exporter_timeout_secs = 3
+
+# Endpoint URL for the OpenTelemetry exporter
+exporter_endpoint = "http://127.0.0.1:4317"

--- a/src/agent/config.rs
+++ b/src/agent/config.rs
@@ -32,6 +32,8 @@ pub struct Config {
     pub metrics_server:        metrics::Config,
     #[serde(default)]
     pub remote_keypair_loader: services::keypairs::Config,
+    #[serde(default)]
+    pub opentelemetry:         OpenTelemetryConfig,
 }
 
 impl Config {
@@ -80,6 +82,22 @@ impl Default for ChannelCapacities {
             local_store:              10000,
             pythd_adapter:            10000,
             logger_buffer:            10000,
+        }
+    }
+}
+
+
+#[derive(Deserialize, Debug)]
+pub struct OpenTelemetryConfig {
+    pub exporter_timeout_secs: u64,
+    pub exporter_endpoint:     String,
+}
+
+impl Default for OpenTelemetryConfig {
+    fn default() -> Self {
+        Self {
+            exporter_timeout_secs: 3,
+            exporter_endpoint:     "http://127.0.0.1:4317".to_string(),
         }
     }
 }

--- a/src/agent/config.rs
+++ b/src/agent/config.rs
@@ -32,8 +32,7 @@ pub struct Config {
     pub metrics_server:        metrics::Config,
     #[serde(default)]
     pub remote_keypair_loader: services::keypairs::Config,
-    #[serde(default)]
-    pub opentelemetry:         OpenTelemetryConfig,
+    pub opentelemetry:         Option<OpenTelemetryConfig>,
 }
 
 impl Config {
@@ -91,13 +90,4 @@ impl Default for ChannelCapacities {
 pub struct OpenTelemetryConfig {
     pub exporter_timeout_secs: u64,
     pub exporter_endpoint:     String,
-}
-
-impl Default for OpenTelemetryConfig {
-    fn default() -> Self {
-        Self {
-            exporter_timeout_secs: 3,
-            exporter_endpoint:     "http://127.0.0.1:4317".to_string(),
-        }
-    }
 }

--- a/src/agent/pyth/rpc.rs
+++ b/src/agent/pyth/rpc.rs
@@ -50,6 +50,7 @@ use {
         sync::Arc,
     },
     tokio::sync::mpsc,
+    tracing::instrument,
     warp::{
         ws::{
             Message,
@@ -411,6 +412,7 @@ impl Default for Config {
     }
 }
 
+#[instrument(skip_all)]
 pub async fn run<S>(config: Config, state: Arc<S>)
 where
     S: state::Prices,

--- a/src/agent/pyth/rpc/get_all_products.rs
+++ b/src/agent/pyth/rpc/get_all_products.rs
@@ -1,8 +1,10 @@
 use {
     crate::agent::state,
     anyhow::Result,
+    tracing::instrument,
 };
 
+#[instrument(skip_all)]
 pub async fn get_all_products<S>(state: &S) -> Result<serde_json::Value>
 where
     S: state::Prices,

--- a/src/agent/pyth/rpc/get_product.rs
+++ b/src/agent/pyth/rpc/get_product.rs
@@ -12,8 +12,10 @@ use {
         Request,
         Value,
     },
+    tracing::instrument,
 };
 
+#[instrument(skip_all, fields(account))]
 pub async fn get_product<S>(
     state: &S,
     request: &Request<Method, Value>,
@@ -27,6 +29,8 @@ where
     }?;
 
     let account = params.account.parse::<solana_sdk::pubkey::Pubkey>()?;
+    tracing::Span::current().record("account", account.to_string());
+
     let product = state.get_product(&account).await?;
     Ok(serde_json::to_value(product)?)
 }

--- a/src/agent/pyth/rpc/get_product_list.rs
+++ b/src/agent/pyth/rpc/get_product_list.rs
@@ -1,8 +1,10 @@
 use {
     crate::agent::state,
     anyhow::Result,
+    tracing::instrument,
 };
 
+#[instrument(skip_all)]
 pub async fn get_product_list<S>(state: &S) -> Result<serde_json::Value>
 where
     S: state::Prices,

--- a/src/agent/pyth/rpc/subscribe_price.rs
+++ b/src/agent/pyth/rpc/subscribe_price.rs
@@ -15,8 +15,10 @@ use {
         Value,
     },
     tokio::sync::mpsc,
+    tracing::instrument,
 };
 
+#[instrument(skip_all, fields(account))]
 pub async fn subscribe_price<S>(
     state: &S,
     notify_price_tx: &mpsc::Sender<NotifyPrice>,
@@ -33,6 +35,8 @@ where
     )?;
 
     let account = params.account.parse::<solana_sdk::pubkey::Pubkey>()?;
+    tracing::Span::current().record("account", account.to_string());
+
     let subscription = state
         .subscribe_price(&account, notify_price_tx.clone())
         .await;

--- a/src/agent/pyth/rpc/subscribe_price_sched.rs
+++ b/src/agent/pyth/rpc/subscribe_price_sched.rs
@@ -15,8 +15,10 @@ use {
         Value,
     },
     tokio::sync::mpsc,
+    tracing::instrument,
 };
 
+#[instrument(skip_all, fields(account))]
 pub async fn subscribe_price_sched<S>(
     state: &S,
     notify_price_sched_tx: &mpsc::Sender<NotifyPriceSched>,
@@ -33,6 +35,8 @@ where
     )?;
 
     let account = params.account.parse::<solana_sdk::pubkey::Pubkey>()?;
+    tracing::Span::current().record("account", account.to_string());
+
     let subscription = state
         .subscribe_price_sched(&account, notify_price_sched_tx.clone())
         .await;

--- a/src/agent/pyth/rpc/update_price.rs
+++ b/src/agent/pyth/rpc/update_price.rs
@@ -12,8 +12,10 @@ use {
         Request,
         Value,
     },
+    tracing::instrument,
 };
 
+#[instrument(skip_all, fields(account))]
 pub async fn update_price<S>(
     state: &S,
     request: &Request<Method, Value>,
@@ -27,6 +29,8 @@ where
             .clone()
             .ok_or_else(|| anyhow!("Missing request parameters"))?,
     )?;
+
+    tracing::Span::current().record("account", params.account.to_string());
 
     state
         .update_local_price(

--- a/src/agent/services/notifier.rs
+++ b/src/agent/services/notifier.rs
@@ -6,8 +6,10 @@
 use {
     crate::agent::state::Prices,
     std::sync::Arc,
+    tracing::instrument,
 };
 
+#[instrument(skip(state))]
 pub async fn notifier<S>(state: Arc<S>)
 where
     S: Prices,

--- a/src/agent/services/oracle.rs
+++ b/src/agent/services/oracle.rs
@@ -152,7 +152,7 @@ where
 }
 
 /// On poll lookup all Pyth Mapping/Product/Price accounts and sync.
-#[instrument(skip(config, state))]
+#[instrument(skip(config, publish_keypair, state))]
 async fn poller<S>(
     config: Config,
     network: Network,

--- a/src/agent/state/api.rs
+++ b/src/agent/state/api.rs
@@ -53,6 +53,7 @@ use {
         mpsc,
         RwLock,
     },
+    tracing::instrument,
 };
 
 // TODO: implement Display on PriceStatus and then just call PriceStatus::to_string
@@ -382,6 +383,10 @@ where
         .map_err(|_| anyhow!("failed to send update to local store"))
     }
 
+    #[instrument(skip(self, update), fields(update = match update {
+        Update::ProductAccountUpdate { account_key, .. } => account_key,
+        Update::PriceAccountUpdate   { account_key, .. } => account_key,
+    }.to_string()))]
     async fn update_global_price(&self, network: Network, update: &Update) -> Result<()> {
         GlobalStore::update(self, network, update)
             .await

--- a/src/agent/state/exporter.rs
+++ b/src/agent/state/exporter.rs
@@ -300,7 +300,7 @@ where
         Ok(())
     }
 
-    #[instrument(skip(self, publisher_permissions))]
+    #[instrument(skip(self, publish_keypair, publisher_permissions))]
     async fn update_permissions(
         &self,
         network: Network,
@@ -323,7 +323,7 @@ where
     }
 }
 
-#[instrument(skip(state))]
+#[instrument(skip(state, publish_keypair))]
 pub async fn get_publish_keypair<S>(
     state: &S,
     network: Network,

--- a/src/agent/state/keypairs.rs
+++ b/src/agent/state/keypairs.rs
@@ -53,7 +53,7 @@ where
         )?)
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self, new_keypair))]
     async fn update_keypair(&self, network: Network, new_keypair: Keypair) {
         *match network {
             Network::Primary => self.into().primary_current_keypair.write().await,

--- a/src/agent/state/keypairs.rs
+++ b/src/agent/state/keypairs.rs
@@ -8,6 +8,7 @@ use {
     anyhow::Result,
     solana_sdk::signature::Keypair,
     tokio::sync::RwLock,
+    tracing::instrument,
 };
 
 #[derive(Default)]
@@ -35,6 +36,7 @@ where
     for<'a> &'a T: Into<&'a KeypairState>,
     T: Sync,
 {
+    #[instrument(skip(self))]
     async fn request_keypair(&self, network: Network) -> Result<Keypair> {
         let keypair = match network {
             Network::Primary => &self.into().primary_current_keypair,
@@ -51,6 +53,7 @@ where
         )?)
     }
 
+    #[instrument(skip(self))]
     async fn update_keypair(&self, network: Network, new_keypair: Keypair) {
         *match network {
             Network::Primary => self.into().primary_current_keypair.write().await,

--- a/src/agent/state/oracle.rs
+++ b/src/agent/state/oracle.rs
@@ -262,7 +262,7 @@ where
     }
 
     /// Poll target Solana based chain for Pyth related accounts.
-    #[instrument(skip(self, rpc_client))]
+    #[instrument(skip(self, publish_keypair, rpc_client))]
     async fn poll_updates(
         &self,
         network: Network,

--- a/src/agent/state/oracle.rs
+++ b/src/agent/state/oracle.rs
@@ -421,6 +421,7 @@ where
     Ok((product_entries, price_entries))
 }
 
+#[instrument(skip(rpc_client, product_key_batch))]
 async fn fetch_batch_of_product_and_price_accounts(
     rpc_client: &RpcClient,
     product_key_batch: &[Pubkey],
@@ -568,6 +569,7 @@ async fn fetch_batch_of_product_and_price_accounts(
     Ok((product_entries, price_entries))
 }
 
+#[instrument(skip(data, new_data))]
 fn log_data_diff(data: &Data, new_data: &Data) {
     // Log new accounts which have been found
     let previous_mapping_accounts = data

--- a/src/agent/state/oracle.rs
+++ b/src/agent/state/oracle.rs
@@ -46,6 +46,7 @@ use {
         time::Duration,
     },
     tokio::sync::RwLock,
+    tracing::instrument,
 };
 
 #[derive(Debug, Clone)]
@@ -96,6 +97,7 @@ impl From<SolanaPriceAccount> for PriceEntry {
 
 impl PriceEntry {
     /// Construct the right underlying GenericPriceAccount based on the account size.
+    #[instrument(skip(acc))]
     pub fn load_from_account(acc: &[u8]) -> Option<Self> {
         unsafe {
             let size = match acc.len() {
@@ -216,6 +218,7 @@ where
     T: Prices,
     T: Exporter,
 {
+    #[instrument(skip(self, account_key))]
     async fn handle_price_account_update(
         &self,
         network: Network,
@@ -259,6 +262,7 @@ where
     }
 
     /// Poll target Solana based chain for Pyth related accounts.
+    #[instrument(skip(self, rpc_client))]
     async fn poll_updates(
         &self,
         network: Network,
@@ -329,6 +333,7 @@ where
     }
 
     /// Sync Product/Price Accounts found by polling to the Global Store.
+    #[instrument(skip(self))]
     async fn sync_global_store(&self, network: Network) -> Result<()> {
         for (product_account_key, product_account) in
             &self.into().data.read().await.product_accounts
@@ -362,6 +367,7 @@ where
     }
 }
 
+#[instrument(skip(rpc_client))]
 async fn fetch_mapping_accounts(
     rpc_client: &RpcClient,
     mapping_account_key: Pubkey,
@@ -381,6 +387,7 @@ async fn fetch_mapping_accounts(
     Ok(accounts)
 }
 
+#[instrument(skip(rpc_client, mapping_accounts))]
 async fn fetch_product_and_price_accounts<'a, A>(
     rpc_client: &RpcClient,
     max_lookup_batch_size: usize,

--- a/src/agent/state/transactions.rs
+++ b/src/agent/state/transactions.rs
@@ -8,6 +8,7 @@ use {
     },
     std::collections::VecDeque,
     tokio::sync::RwLock,
+    tracing::instrument,
 };
 
 #[derive(Default)]
@@ -44,6 +45,7 @@ where
     for<'a> &'a T: Into<&'a TransactionsState>,
     T: Sync + Send + 'static,
 {
+    #[instrument(skip(self))]
     async fn add_transaction(&self, signature: Signature) {
         tracing::debug!(
             signature = signature.to_string(),
@@ -60,6 +62,7 @@ where
         }
     }
 
+    #[instrument(skip(self, rpc))]
     async fn poll_transactions_status(&self, rpc: &RpcClient) -> Result<()> {
         let mut txs = self.into().sent_transactions.write().await;
         if txs.is_empty() {

--- a/src/bin/agent.rs
+++ b/src/bin/agent.rs
@@ -16,7 +16,10 @@ use {
         path::PathBuf,
         time::Duration,
     },
-    tracing_subscriber::prelude::*,
+    tracing_subscriber::{
+        prelude::*,
+        EnvFilter,
+    },
 };
 
 #[derive(Parser, Debug)]
@@ -44,6 +47,8 @@ async fn main() -> Result<()> {
 
     // Parse config early for logging channel capacity
     let config = Config::new(args.config).context("Could not parse config")?;
+
+    let env_filter = EnvFilter::from_default_env();
 
     // Initialize a Tracing Subscriber
     let fmt_layer = tracing_subscriber::fmt::layer()
@@ -73,7 +78,9 @@ async fn main() -> Result<()> {
     // Set up the telemetry layer
     let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
 
-    let registry = tracing_subscriber::registry().with(telemetry);
+    let registry = tracing_subscriber::registry()
+        .with(telemetry)
+        .with(env_filter);
 
     // Use the compact formatter if we're in a terminal, otherwise use the JSON formatter.
     if std::io::stderr().is_terminal() {


### PR DESCRIPTION
This PR enhances tracing by introducing the `#[instrument]` macro to more functions and adding additional fields to the current span in `get_product.rs`, `subscribe_price.rs`, and `subscribe_price_sched.rs`. This approach is async safe as it maintains the reference to the current span without manual enter/exit, ensuring the tracing context is preserved across await points. We should avoid manual enter/exit tracing logs already handled by `#[instrument]`, and any custom spans should be cautious of this behavior to avoid manual span entry.