### PR TITLE
fix: use env filter properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "2.10.0"
+version = "2.10.1"
 edition = "2021"
 
 [[bin]]

--- a/src/bin/agent.rs
+++ b/src/bin/agent.rs
@@ -58,7 +58,6 @@ async fn main() -> Result<()> {
         .with_ansi(std::io::stderr().is_terminal());
 
     let mut layers = Vec::new();
-    layers.push(env_filter.boxed());
 
     // Set up OpenTelemetry only if it's configured
     if let Some(opentelemetry_config) = &config.opentelemetry {
@@ -91,7 +90,10 @@ async fn main() -> Result<()> {
         layers.push(fmt_layer.json().boxed());
     }
 
-    tracing_subscriber::registry().with(layers).init();
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(layers)
+        .init();
 
     // Launch the application. If it fails, print the full backtrace and exit. RUST_BACKTRACE
     // should be set to 1 for this otherwise it will only print the top-level error.


### PR DESCRIPTION
Apparently if we pass env filter in an array with the other layers it won't be executed first (to act as a filter). This change fixes that by explicitly adding it before.