### PR TITLE
fix: spawn transaction senders in exporter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "2.10.1"
+version = "2.10.2"
 edition = "2021"
 
 [[bin]]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
+channel = "1.79.0"
 profile = "minimal"
 components = ["rustfmt", "clippy"]

--- a/src/agent/services/exporter.rs
+++ b/src/agent/services/exporter.rs
@@ -262,7 +262,7 @@ mod exporter {
                             config.exporter.unchanged_publish_threshold,
                         ).await {
                             if let Err(err) = publish_batches(
-                                &*state,
+                                state.clone(),
                                 client.clone(),
                                 network,
                                 &network_state_rx,


### PR DESCRIPTION
During refactoring the async spawning of the transaction sender was removed but not added back.