### PR TITLE
fix: feed rpc responses and notifications instead of send and flush

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "2.10.1"
+version = "2.10.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "2.10.2"
+version = "2.10.3"
 edition = "2021"
 
 [[bin]]

--- a/config/config.toml
+++ b/config/config.toml
@@ -6,6 +6,18 @@
 # connection is not exposed for unauthorized access.
 listen_address = "127.0.0.1:8910"
 
+# Size of the buffer of each Server's channel on which `notify_price` events are
+# received from the Price state.
+# notify_price_tx_buffer = 10000
+
+# Size of the buffer of each Server's channel on which `notify_price_sched` events are
+# received from the Price state.
+# notify_price_sched_tx_buffer = 10000
+
+# Flush interval for responses and notifications. This is the maximum time the
+# server will wait before flushing the messages to the client.
+# flush_interval_duration = "50ms"
+
 # Configuration for the primary network this agent will publish data to. In most cases this should be a Pythnet endpoint.
 [primary_network]
 ### Required fields ###

--- a/config/config.toml
+++ b/config/config.toml
@@ -198,8 +198,8 @@ key_store.mapping_key = "RelevantOracleMappingAddress"
 ## Configuration for OpenTelemetry ##
 [opentelemetry]
 
-# Timeout in seconds for the OpenTelemetry exporter
-exporter_timeout_secs = 3
+# Timeout duration for the OpenTelemetry exporter
+exporter_timeout_duration = "3s"
 
 # Endpoint URL for the OpenTelemetry exporter
 exporter_endpoint = "http://127.0.0.1:4317"

--- a/src/agent/config.rs
+++ b/src/agent/config.rs
@@ -13,7 +13,10 @@ use {
         File,
     },
     serde::Deserialize,
-    std::path::Path,
+    std::{
+        path::Path,
+        time::Duration,
+    },
 };
 
 /// Configuration for all components of the Agent
@@ -88,6 +91,7 @@ impl Default for ChannelCapacities {
 
 #[derive(Deserialize, Debug)]
 pub struct OpenTelemetryConfig {
-    pub exporter_timeout_secs: u64,
-    pub exporter_endpoint:     String,
+    #[serde(with = "humantime_serde")]
+    pub exporter_timeout_duration: Duration,
+    pub exporter_endpoint:         String,
 }

--- a/src/bin/agent.rs
+++ b/src/bin/agent.rs
@@ -14,7 +14,6 @@ use {
     std::{
         io::IsTerminal,
         path::PathBuf,
-        time::Duration,
     },
     tracing_subscriber::{
         prelude::*,
@@ -65,9 +64,7 @@ async fn main() -> Result<()> {
         let otlp_exporter = opentelemetry_otlp::new_exporter()
             .tonic()
             .with_endpoint(&opentelemetry_config.exporter_endpoint)
-            .with_timeout(Duration::from_secs(
-                opentelemetry_config.exporter_timeout_secs,
-            ));
+            .with_timeout(opentelemetry_config.exporter_timeout_duration);
 
         // Set up the OpenTelemetry tracer
         let tracer = opentelemetry_otlp::new_pipeline()


### PR DESCRIPTION
We might send thousands of messages per second to the clients and `send` method flushes each request which might take a longer time. This change changes our responses and notifications to `feed` and flushes the messages based on a configured interval (default: 100ms).

There is a small refactor of a config in the previous changes to make it match our configuration style.