### PR TITLE
Update config.sample.pythnet.toml

### DIFF
--- a/config/config.sample.pythnet.toml
+++ b/config/config.sample.pythnet.toml
@@ -20,6 +20,9 @@ key_store.program_key = "FsJ3A3u2vn5cTVofAjvy6y5kwABJAqYWpe4975bi2epH"
 # Oracle mapping pubkey
 key_store.mapping_key = "AHtgzX45WTKfkPG53L6WYhGEXwQkN1BVknET3sVsLL8J"
 
+# Compute unit per price update.
+exporter.compute_unit_limit = 5000
+
 # Configuration for the JRPC API
 [pythd_adapter]
 

--- a/config/config.sample.pythnet.toml
+++ b/config/config.sample.pythnet.toml
@@ -20,18 +20,6 @@ key_store.program_key = "FsJ3A3u2vn5cTVofAjvy6y5kwABJAqYWpe4975bi2epH"
 # Oracle mapping pubkey
 key_store.mapping_key = "AHtgzX45WTKfkPG53L6WYhGEXwQkN1BVknET3sVsLL8J"
 
-# Pythnet accumulator key
-# The pythnet accumulator key settings are only valid for pythnet. Do not apply
-# these settings for any other environment i.e. mainnet, pythtest-conformance
-key_store.accumulator_key = "7Vbmv1jt4vyuqBZcpYPpnVhrqVe5e6ZPb6JxDcffRHUM"
-
-# IMPORTANT: Exporter batch size must be decreased to 7 to support
-# larger accumulator transactions, when accumulator_key is set.
-exporter.max_batch_size = 7
-
-# Duration of the interval at which to publish updates
-exporter.publish_interval_duration = "1s"
-
 # Configuration for the JRPC API
 [pythd_adapter]
 


### PR DESCRIPTION
After the migration of the aggregation to the validator we no longer need to pass accumulator key and the batch size no longer needs to be set to 7. Also because of the recent network performance, we can reduce the publish_interval.