### PR TITLE
chore: add price_info log in local store update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "2.11.0"
+version = "2.11.1"
 edition = "2021"
 
 [[bin]]

--- a/src/agent/state/local.rs
+++ b/src/agent/state/local.rs
@@ -84,6 +84,7 @@ where
     ) -> Result<()> {
         tracing::debug!(
             identifier = bs58::encode(price_identifier.to_bytes()).into_string(),
+            price_update = ?price_info,
             "Local store received price update."
         );
 


### PR DESCRIPTION
This log can be helpful for publishers who want to confirm whether their price updates are being received by the agent or not.