### PR TITLE
Fix: Update config samples with more descriptive pyth_oracle_ for

### DIFF
--- a/config/config.sample.pythnet.toml
+++ b/config/config.sample.pythnet.toml
@@ -15,7 +15,7 @@ wss_url = "wss://api2.pythnet.pyth.network"
 key_store.publish_keypair_path = "/path/to/keypair.json"
 
 # Oracle program pubkey
-key_store.program_key = "FsJ3A3u2vn5cTVofAjvy6y5kwABJAqYWpe4975bi2epH"
+key_store.pyth_oracle_program_key = "FsJ3A3u2vn5cTVofAjvy6y5kwABJAqYWpe4975bi2epH"
 
 # The price store program key
 key_store.pyth_price_store_program_key = "3m6sv6HGqEbuyLV84mD7rJn4MAC9LhUa1y1AUNVqcPfr"

--- a/config/config.sample.pythtest.toml
+++ b/config/config.sample.pythtest.toml
@@ -15,8 +15,8 @@ wss_url = "wss://api.pythtest.pyth.network"
 key_store.publish_keypair_path = "/path/to/keypair.json"
 
 # Oracle program pubkey
-key_store.program_key = "8tfDNiaEyrV6Q1U4DEXrEigs9DoDtkugzFbybENEbCDz" # conformance
-# key_store.program_key = "gSbePebfvPy7tRqimPoVecS2UsBvYv46ynrzWocc92s" # cross-chain
+key_store.pyth_oracle_program_key = "8tfDNiaEyrV6Q1U4DEXrEigs9DoDtkugzFbybENEbCDz" # conformance
+# key_store.pyth_oracle_program_key = "gSbePebfvPy7tRqimPoVecS2UsBvYv46ynrzWocc92s" # cross-chain
 
 # Pythtest accumulator key (only for the cross-chain oracle)
 # key_store.accumulator_key = "7Vbmv1jt4vyuqBZcpYPpnVhrqVe5e6ZPb6JxDcffRHUM"

--- a/config/config.toml
+++ b/config/config.toml
@@ -45,7 +45,7 @@ wss_url = "wss://api.pythtest.pyth.network"
 key_store.publish_keypair_path = "/path/to/keypair.json"
 
 # Public key of the oracle program
-key_store.program_key = "RelevantOracleProgramAddress"
+key_store.pyth_oracle_program_key = "RelevantOracleProgramAddress"
 
 # The price store program key
 key_store.pyth_price_store_program_key = "3m6sv6HGqEbuyLV84mD7rJn4MAC9LhUa1y1AUNVqcPfr"

--- a/integration-tests/tests/test_integration.py
+++ b/integration-tests/tests/test_integration.py
@@ -420,7 +420,7 @@ class PythTest:
 
             agent_config += f"""
 key_store.publish_keypair_path = "{publish_keypair_path}"
-key_store.program_key = "{ORACLE_PROGRAM}"
+key_store.pyth_oracle_program_key = "{ORACLE_PROGRAM}"
 """
 
             # Add accumulator setting if option is enabled


### PR DESCRIPTION
program key

This change was made in the codebase already but didn't make it into the samples. Now that there's 2 program_key entries this makes it clear what they are used for