### PR TITLE
Publish a Minimal Container Image to ECR Public

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 target
 Dockerfile
+agent.Dockerfile

--- a/.github/workflows/image-push.yaml
+++ b/.github/workflows/image-push.yaml
@@ -15,6 +15,13 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    strategy:
+      matrix:
+        dockerfile:
+          - file: "Dockerfile"
+            suffix: ""
+          - file: "agent.Dockerfile"
+            suffix: "-minimal"
     steps:
       - uses: actions/checkout@v2
       - uses: aws-actions/configure-aws-credentials@8a84b07f2009032ade05a88a28750d733cc30db1
@@ -40,4 +47,5 @@ jobs:
       - uses: docker/build-push-action@v2
         with:
           push: true
-          tags: public.ecr.aws/pyth-network/agent:${{ steps.image_tag.outputs.value }}
+          tags: public.ecr.aws/pyth-network/agent:${{ steps.image_tag.outputs.value }}${{ matrix.dockerfile.suffix }}
+          file: ${{ matrix.dockerfile.file }}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,19 @@ through the `RUST_LOG` environment variable using the standard
 Pyth agent will print logs in plaintext in terminal and JSON format in non-terminal environments (e.g. when writing to a file).
 
 ## Run
-`cargo run --release -- --config <your_config.toml>` will build and run the agent in a single step.
+### From Source
+The preferred way to run Pyth Agent is by compiling from source. You can run the below command to build and run the agent in a single step.
+
+```bash
+cargo run --release -- --config <your_config.toml>
+```
+
+### Container
+For convenience, a minimal container image is also published to [ECR Public](https://gallery.ecr.aws/pyth-network/agent). An example command for running this container can be found below. Make sure to update the image version to the latest release of Pyth Agent.
+
+```bash
+docker run -v /path/to/configdir:/config:z,ro public.ecr.aws/pyth-network/agent:v2.12.0-minimal
+```
 
 ## Publishing API
 A running agent will expose a WebSocket serving the JRPC publishing API documented [here](https://docs.pyth.network/documentation/publish-data/pyth-client-websocket-api). See `config/config.toml` for related settings.


### PR DESCRIPTION
Running the current full-size image in a production deployment isn't really feasible, but the minimal container image already in this repo already has everything required. We're looking to move our Pyth Publisher into Kubernetes and this would make that change much easier.

To give you some idea of the size difference:
```bash
$ podman images --format "table {{.ID}} {{.Repository}} {{.Size}}" | grep -E "(pyth-network|6a18b7d)"
6a18b7d60f62  <none>                             136 MB
774cbbe966e0  public.ecr.aws/pyth-network/agent  5.83 GB
```

It'd probably also be worthwhile to upload a basic `About` and Icon to ECR Public to help users know they've found the correct page. Some guidance on doing that can be found on <https://docs.aws.amazon.com/AmazonECR/latest/public/public-repository-catalog-data.html>.