### PR TITLE
Bump Ubuntu release

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check-out code
         uses: actions/checkout@v2


### PR DESCRIPTION
GitHub deprecating Ubuntu 20.04:
https://github.com/actions/runner-images/issues/11101