### PR TITLE
Fix tokio task leak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "2.12.1"
+version = "2.12.2"
 edition = "2021"
 
 [[bin]]

--- a/config/config.toml
+++ b/config/config.toml
@@ -73,6 +73,15 @@ key_store.pyth_price_store_program_key = "3m6sv6HGqEbuyLV84mD7rJn4MAC9LhUa1y1AUN
 # takes to fetch all symbols.
 # oracle.max_lookup_batch_size = 100
 
+# Number of workers used to wait for the handle_price_account_update
+# oracle.handle_price_account_update_worker_poll_size = 25
+# Channel size used to wait for the handle_price_account_update
+# oracle.handle_price_account_update_channel_size = 1000
+# Minimum time for a subscriber to run
+# oracle.subscriber_finished_min_time = "30s"
+# Time to sleep if the subscriber do not run for more than the minimum time
+# oracle.subscriber_finished_sleep_time = "1s"
+
 # How often to refresh the cached network state (current slot and blockhash).
 # It is recommended to set this to slightly less than the network's block time,
 # as the slot fetched will be used as the time of the price update.

--- a/config/config.toml
+++ b/config/config.toml
@@ -73,10 +73,6 @@ key_store.pyth_price_store_program_key = "3m6sv6HGqEbuyLV84mD7rJn4MAC9LhUa1y1AUN
 # takes to fetch all symbols.
 # oracle.max_lookup_batch_size = 100
 
-# Number of workers used to wait for the handle_price_account_update
-# oracle.handle_price_account_update_worker_poll_size = 25
-# Channel size used to wait for the handle_price_account_update
-# oracle.handle_price_account_update_channel_size = 1000
 # Minimum time for a subscriber to run
 # oracle.subscriber_finished_min_time = "30s"
 # Time to sleep if the subscriber do not run for more than the minimum time

--- a/src/agent/services/oracle.rs
+++ b/src/agent/services/oracle.rs
@@ -67,11 +67,11 @@ where
     )));
 
     if config.oracle.subscriber_enabled {
-        let number_of_workers = 100;
-        let channel_size = 1000;
-        let (sender, receiver) = tokio::sync::mpsc::channel(channel_size);
-        let max_elapsed_time = Duration::from_secs(30);
-        let sleep_time = Duration::from_secs(1);
+        let number_of_workers = config.oracle.handle_price_account_update_worker_poll_size;
+        let (sender, receiver) =
+            tokio::sync::mpsc::channel(config.oracle.handle_price_account_update_channel_size);
+        let min_elapsed_time = config.oracle.subscriber_finished_min_time;
+        let sleep_time = config.oracle.subscriber_finished_sleep_time;
 
         handles.push(tokio::spawn(async move {
             loop {
@@ -86,7 +86,7 @@ where
                 .await
                 {
                     tracing::error!(?err, "Subscriber exited unexpectedly");
-                    if current_time.elapsed() < max_elapsed_time {
+                    if current_time.elapsed() < min_elapsed_time {
                         tracing::warn!(?sleep_time, "Subscriber restarting too quickly. Sleeping");
                         tokio::time::sleep(sleep_time).await;
                     }

--- a/src/agent/services/oracle.rs
+++ b/src/agent/services/oracle.rs
@@ -13,7 +13,10 @@ use {
         },
         state::oracle::Oracle,
     },
-    anyhow::{Context, Result},
+    anyhow::{
+        Context,
+        Result,
+    },
     solana_account_decoder::UiAccountEncoding,
     solana_client::{
         nonblocking::{

--- a/src/agent/services/oracle.rs
+++ b/src/agent/services/oracle.rs
@@ -13,10 +13,7 @@ use {
         },
         state::oracle::Oracle,
     },
-    anyhow::{
-        Context,
-        Result,
-    },
+    anyhow::Result,
     solana_account_decoder::UiAccountEncoding,
     solana_client::{
         nonblocking::{
@@ -36,10 +33,7 @@ use {
     },
     std::{
         sync::Arc,
-        time::{
-            Duration,
-            Instant,
-        },
+        time::Instant,
     },
     tokio::task::JoinHandle,
     tokio_stream::StreamExt,

--- a/src/agent/state/oracle.rs
+++ b/src/agent/state/oracle.rs
@@ -181,30 +181,30 @@ pub struct Config {
     pub handle_price_account_update_worker_poll_size: usize,
     /// Channel size used to wait for the handle_price_account_update
     #[serde(default = "default_handle_price_account_update_channel_size")]
-    pub handle_price_account_update_channel_size: usize,
+    pub handle_price_account_update_channel_size:     usize,
     /// Minimum time for a subscriber to run
     #[serde(default = "default_subscriber_finished_min_time")]
-    pub subscriber_finished_min_time: Duration,
+    pub subscriber_finished_min_time:                 Duration,
     /// Time to sleep if the subscriber do not run for more than the minimum time
     #[serde(default = "default_subscriber_finished_sleep_time")]
-    pub subscriber_finished_sleep_time: Duration,
+    pub subscriber_finished_sleep_time:               Duration,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
-            commitment:               CommitmentLevel::Confirmed,
-            poll_interval_duration:   Duration::from_secs(5),
-            subscriber_enabled:       true,
-            updates_channel_capacity: 10000,
-            data_channel_capacity:    10000,
-            max_lookup_batch_size:    100,
+            commitment:                                   CommitmentLevel::Confirmed,
+            poll_interval_duration:                       Duration::from_secs(5),
+            subscriber_enabled:                           true,
+            updates_channel_capacity:                     10000,
+            data_channel_capacity:                        10000,
+            max_lookup_batch_size:                        100,
             handle_price_account_update_worker_poll_size:
                 default_handle_price_account_update_worker_poll_size(),
             handle_price_account_update_channel_size:
                 default_handle_price_account_update_channel_size(),
-            subscriber_finished_min_time: default_subscriber_finished_min_time(),
-            subscriber_finished_sleep_time: default_subscriber_finished_sleep_time(),
+            subscriber_finished_min_time:                 default_subscriber_finished_min_time(),
+            subscriber_finished_sleep_time:               default_subscriber_finished_sleep_time(),
         }
     }
 }

--- a/src/agent/state/oracle.rs
+++ b/src/agent/state/oracle.rs
@@ -143,7 +143,7 @@ fn default_handle_price_account_update_channel_size() -> usize {
 }
 
 fn default_handle_price_account_update_worker_poll_size() -> usize {
-    50
+    25
 }
 
 fn default_subscriber_finished_min_time() -> Duration {

--- a/src/agent/state/oracle.rs
+++ b/src/agent/state/oracle.rs
@@ -138,6 +138,22 @@ pub struct Data {
     pub publisher_buffer_key:  Option<Pubkey>,
 }
 
+fn default_handle_price_account_update_channel_size() -> usize {
+    1000
+}
+
+fn default_handle_price_account_update_worker_poll_size() -> usize {
+    50
+}
+
+fn default_subscriber_finished_min_time() -> Duration {
+    Duration::from_secs(30)
+}
+
+fn default_subscriber_finished_sleep_time() -> Duration {
+    Duration::from_secs(1)
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(default)]
 pub struct Config {
@@ -159,6 +175,19 @@ pub struct Config {
     /// socket count at bay, the batches are looked up sequentially,
     /// trading off overall time it takes to fetch all symbols.
     pub max_lookup_batch_size: usize,
+
+    /// Number of workers used to wait for the handle_price_account_update
+    #[serde(default = "default_handle_price_account_update_worker_poll_size")]
+    pub handle_price_account_update_worker_poll_size: usize,
+    /// Channel size used to wait for the handle_price_account_update
+    #[serde(default = "default_handle_price_account_update_channel_size")]
+    pub handle_price_account_update_channel_size: usize,
+    /// Minimum time for a subscriber to run
+    #[serde(default = "default_subscriber_finished_min_time")]
+    pub subscriber_finished_min_time: Duration,
+    /// Time to sleep if the subscriber do not run for more than the minimum time
+    #[serde(default = "default_subscriber_finished_sleep_time")]
+    pub subscriber_finished_sleep_time: Duration,
 }
 
 impl Default for Config {
@@ -170,6 +199,12 @@ impl Default for Config {
             updates_channel_capacity: 10000,
             data_channel_capacity:    10000,
             max_lookup_batch_size:    100,
+            handle_price_account_update_worker_poll_size:
+                default_handle_price_account_update_worker_poll_size(),
+            handle_price_account_update_channel_size:
+                default_handle_price_account_update_channel_size(),
+            subscriber_finished_min_time: default_subscriber_finished_min_time(),
+            subscriber_finished_sleep_time: default_subscriber_finished_sleep_time(),
         }
     }
 }

--- a/src/agent/state/oracle.rs
+++ b/src/agent/state/oracle.rs
@@ -138,14 +138,6 @@ pub struct Data {
     pub publisher_buffer_key:  Option<Pubkey>,
 }
 
-fn default_handle_price_account_update_channel_size() -> usize {
-    1000
-}
-
-fn default_handle_price_account_update_worker_poll_size() -> usize {
-    25
-}
-
 fn default_subscriber_finished_min_time() -> Duration {
     Duration::from_secs(30)
 }
@@ -176,35 +168,25 @@ pub struct Config {
     /// trading off overall time it takes to fetch all symbols.
     pub max_lookup_batch_size: usize,
 
-    /// Number of workers used to wait for the handle_price_account_update
-    #[serde(default = "default_handle_price_account_update_worker_poll_size")]
-    pub handle_price_account_update_worker_poll_size: usize,
-    /// Channel size used to wait for the handle_price_account_update
-    #[serde(default = "default_handle_price_account_update_channel_size")]
-    pub handle_price_account_update_channel_size:     usize,
     /// Minimum time for a subscriber to run
     #[serde(default = "default_subscriber_finished_min_time")]
-    pub subscriber_finished_min_time:                 Duration,
+    pub subscriber_finished_min_time:   Duration,
     /// Time to sleep if the subscriber do not run for more than the minimum time
     #[serde(default = "default_subscriber_finished_sleep_time")]
-    pub subscriber_finished_sleep_time:               Duration,
+    pub subscriber_finished_sleep_time: Duration,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
-            commitment:                                   CommitmentLevel::Confirmed,
-            poll_interval_duration:                       Duration::from_secs(5),
-            subscriber_enabled:                           true,
-            updates_channel_capacity:                     10000,
-            data_channel_capacity:                        10000,
-            max_lookup_batch_size:                        100,
-            handle_price_account_update_worker_poll_size:
-                default_handle_price_account_update_worker_poll_size(),
-            handle_price_account_update_channel_size:
-                default_handle_price_account_update_channel_size(),
-            subscriber_finished_min_time:                 default_subscriber_finished_min_time(),
-            subscriber_finished_sleep_time:               default_subscriber_finished_sleep_time(),
+            commitment:                     CommitmentLevel::Confirmed,
+            poll_interval_duration:         Duration::from_secs(5),
+            subscriber_enabled:             true,
+            updates_channel_capacity:       10000,
+            data_channel_capacity:          10000,
+            max_lookup_batch_size:          100,
+            subscriber_finished_min_time:   default_subscriber_finished_min_time(),
+            subscriber_finished_sleep_time: default_subscriber_finished_sleep_time(),
         }
     }
 }

--- a/src/agent/state/oracle.rs
+++ b/src/agent/state/oracle.rs
@@ -241,6 +241,7 @@ where
         );
 
         data.price_accounts.insert(*account_key, price_entry.into());
+        drop(data);
 
         Prices::update_global_price(
             self,
@@ -333,13 +334,16 @@ where
         let mut data = self.into().data.write().await;
         log_data_diff(&data, &new_data);
         *data = new_data;
+        let data_publisher_permissions = data.publisher_permissions.clone();
+        let data_publisher_buffer_key = data.publisher_buffer_key;
+        drop(data);
 
         Exporter::update_on_chain_state(
             self,
             network,
             publish_keypair,
-            data.publisher_permissions.clone(),
-            data.publisher_buffer_key,
+            data_publisher_permissions,
+            data_publisher_buffer_key,
         )
         .await?;
 


### PR DESCRIPTION
While running the agent  version `v.2.12.1`, it crashed after some time with an out of memory issue, having to be killed by the OS.
The machine I was using has 48GB of RAM

It was happening for both mainet and testnet.

I did not see anything particularly special about the resources it was using:
![tokio_console_resources-pr](https://github.com/user-attachments/assets/c4747bbd-ff47-4dfd-b255-71ba6549ecf7)

But the number of tasks seems large.
![tokio_console_threads-pr](https://github.com/user-attachments/assets/5e1e4293-a6c5-4f4e-903b-f80ae2539ffb)

One can see 7721 tasks while a lot of them are idle for some time.
After observing it, the number of tasks would increase with time until the point it would, the binary would be killed.
The idle tasks are created here https://github.com/pyth-network/pyth-agent/blob/main/src/agent/services/oracle.rs#L132 as can be seen in the image, where the subscriber is handling the `handle_price_account_update`.
That line is crating tokio tasks without keeping track of the task handle `JoinHandle`, in cases where those are created faster than they are `.await`ed this can lead to a leak.

After the proposed change I can see a much more comfortable number of tasks:
![tokio-console_threads_after-pr](https://github.com/user-attachments/assets/4ff857bb-1625-4468-9a67-2a69bfa47e66)
The number of tasks now is stable around 100, being 114 in the attached image.
It is worthy mentioning that I used 100 worker tasks to wait for the previously leaked ones to finish, so this number can be way smaller with another configuration.

In order to reproduce the tokio console one can follow the instructions in https://github.com/tokio-rs/console which are basic:
- Install tokio-console with `cargo install --locked tokio-console`
- Add `console-subscriber = "0.3.0"` as a dependency
- Add `console_subscriber::init();` as the first line in the `main` funciton
- Run the binary with `RUSTFLAGS="--cfg tokio_unstable" cargo run --bin agent -- --config <config file path>`
- Run `tokio-console` to watch its data