### PR TITLE
Reduce memory usage, faster copies and other small improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4052,9 +4052,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring 0.17.8",
@@ -4487,9 +4487,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b359495f76e0570a3e611e8963f4703828f7516e6577d38d642644ad205c16"
+checksum = "b109fd3a106e079005167e5b0e6f6d2c88bbedec32530837b584791a8b5abf36"
 dependencies = [
  "Inflector",
  "base64 0.21.7",
@@ -4512,9 +4512,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d44534a77097037399d613994d521a3bb56ce63d423d77efdb1d4b06666d2d"
+checksum = "074ef478856a45d5627270fbc6b331f91de9aae7128242d9e423931013fb8a2a"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -4529,9 +4529,9 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55322d541c2147ea979832641ca718651eb7a9284fa25b9d6c4cb21fd6f1850"
+checksum = "24a9f32c42402c4b9484d5868ac74b7e0a746e3905d8bfd756e1203e50cbb87e"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4562,9 +4562,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63f328bb6c0a8013218fb71ef31c6524359eae1d328f4ffef4d14e3e7141f84f"
+checksum = "9d75b803860c0098e021a26f0624129007c15badd5b0bc2fbd9f0e1a73060d3b"
 dependencies = [
  "bincode",
  "chrono",
@@ -4576,9 +4576,9 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb39f5996aa944722975efe70adb01f91705cf42e0d302eacb868f51d5c92601"
+checksum = "b9306ede13e8ceeab8a096bcf5fa7126731e44c201ca1721ea3c38d89bcd4111"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4598,9 +4598,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033e98b727d281cc22381ff703f58b70822b8c32ddb7aca9e7eb3a9c1d465371"
+checksum = "03ab2c30c15311b511c0d1151e4ab6bc9a3e080a37e7c6e7c2d96f5784cf9434"
 dependencies = [
  "block-buffer 0.10.4",
  "bs58",
@@ -4623,9 +4623,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aab7183079f7a0c0b71454fd365e12bce9a773b8099f6c2a92ba6887c42a9d0f"
+checksum = "c142f779c3633ac83c84d04ff06c70e1f558c876f13358bed77ba629c7417932"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4635,9 +4635,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5559aeadd3adc219fa7169e96a8c5dda618c7f06985f91f2a5f55b9814c7a2"
+checksum = "121d36ffb3c6b958763312cbc697fbccba46ee837d3a0aa4fc0e90fcb3b884f3"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -4646,9 +4646,9 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "041ab11f1e02d4dbe4f45e6854c312ae2518a5cbe3327b767cab2bc9a8fc0740"
+checksum = "5c01a7f9cdc9d9d37a3d5651b2fe7ec9d433c2a3470b9f35897e373b421f0737"
 dependencies = [
  "log",
  "solana-sdk",
@@ -4656,9 +4656,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aab373e70aa970e62d16ba1e7e21c54519582c57b680fd31d80421aa3a983a1"
+checksum = "71e36052aff6be1536bdf6f737c6e69aca9dbb6a2f3f582e14ecb0ddc0cd66ce"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -4671,9 +4671,9 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736fc2f0fc5a0948d8cb74152d68733c7a682ff8b8ef8df27e75d164c2ed6969"
+checksum = "2a1f5c6be9c5b272866673741e1ebc64b2ea2118e5c6301babbce526fdfb15f4"
 dependencies = [
  "bincode",
  "clap 3.2.25",
@@ -4693,9 +4693,9 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e9a1f74df1265cc43c843367a833cff05b8a1b5467676ae540f479751aab3c"
+checksum = "28acaf22477566a0fbddd67249ea5d859b39bacdb624aff3fadd3c5745e2643c"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -4722,9 +4722,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0af84e0c085510c9d1660d1f7e50e8b94ec97f27e23e13d960db353d98b55c8a"
+checksum = "c10f4588cefd716b24a1a40dd32c278e43a560ab8ce4de6b5805c9d113afdfa1"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -4777,9 +4777,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69c13c6ac710cb7e4325de42e7f382109d0b9d6495942b38d0e4b528a8a9961a"
+checksum = "fbf0c3eab2a80f514289af1f422c121defb030937643c43b117959d6f1932fb5"
 dependencies = [
  "base64 0.21.7",
  "bincode",
@@ -4805,9 +4805,9 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c0575b3106c15019ad451cc81d5bf328ab07a27e0eadc4af31740b88faf586"
+checksum = "b064e76909d33821b80fdd826e6757251934a52958220c92639f634bea90366d"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -4830,9 +4830,9 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a81e5186b7cf170616579921da3027b6f94f7275153d38e83b9b2be3fb07ac2"
+checksum = "5a90e40ee593f6e9ddd722d296df56743514ae804975a76d47e7afed4e3da244"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -4857,9 +4857,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881229e01194a0fc5d6115867d2ee5ce0abfb80d53cab3822c4a6bf96210d474"
+checksum = "66468f9c014992167de10cc68aad6ac8919a8c8ff428dc88c0d2b4da8c02b8b7"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -4867,9 +4867,9 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf5b80ef02505a7cd7e248c25f839ba5669a13595462eac212dde0895d690ad"
+checksum = "c191019f4d4f84281a6d0dd9a43181146b33019627fc394e42e08ade8976b431"
 dependencies = [
  "console",
  "dialoguer",
@@ -4886,9 +4886,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb2a4cace9ef7c02062efdaa54cfefa13c91fa48cc0c827852adadf7e406963"
+checksum = "36ed4628e338077c195ddbf790693d410123d17dec0a319b5accb4aaee3fb15c"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -4912,9 +4912,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb658d90dca6aece251e0d4288e6e1b06c1b10315abb118032a2e230f8d872f"
+checksum = "83c913551faa4a1ae4bbfef6af19f3a5cf847285c05b4409e37c8993b3444229"
 dependencies = [
  "base64 0.21.7",
  "bs58",
@@ -4934,9 +4934,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2d0a1b6936a90b1d831a32605118c6f11d7c0dd3b37fb174eab5e1a0b5f3"
+checksum = "1a47b6bb1834e6141a799db62bbdcf80d17a7d58d7bc1684c614e01a7293d7cf"
 dependencies = [
  "clap 2.34.0",
  "solana-clap-utils",
@@ -4947,9 +4947,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68caf1d34891521523df18dc3c13ce20d54a59c3a390729450267a4c9aa96017"
+checksum = "580ad66c2f7a4c3cb3244fe21440546bd500f5ecb955ad9826e92a78dded8009"
 dependencies = [
  "assert_matches",
  "base64 0.21.7",
@@ -5002,9 +5002,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cff24eec74815028ebcffe639cf63ff50fb78dadcbf71a8b95b44e7ad1bb6b2"
+checksum = "1b75d0f193a27719257af19144fdaebec0415d1c9e9226ae4bd29b791be5e9bd"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -5021,9 +5021,9 @@ checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 
 [[package]]
 name = "solana-streamer"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af7e0e90d5b6e4aa7182b9f8221fe5a9da4106afc031ac3697a860c2da7c8ac"
+checksum = "f8476e41ad94fe492e8c06697ee35912cf3080aae0c9e9ac6430835256ccf056"
 dependencies = [
  "async-channel",
  "bytes",
@@ -5043,6 +5043,7 @@ dependencies = [
  "rand 0.8.5",
  "rcgen",
  "rustls",
+ "smallvec",
  "solana-metrics",
  "solana-perf",
  "solana-sdk",
@@ -5053,9 +5054,9 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e55c9d6f7970a9e846256bbf57a571ada379fb300ba39958992fbadf5c24ca5"
+checksum = "d8c02245d0d232430e79dc0d624aa42d50006097c3aec99ac82ac299eaa3a73f"
 dependencies = [
  "bincode",
  "log",
@@ -5068,9 +5069,9 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8859de54d3fbfee458b11536af0f357977044c3b31c9a1154af5c8874ae485"
+checksum = "67251506ed03de15f1347b46636b45c47da6be75015b4a13f0620b21beb00566"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5092,9 +5093,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2be62abd39aad39d5377e3ad4f1af7fc7e12577edb0d6ac6405f533f9ce74e7"
+checksum = "2d3d36db1b2ab2801afd5482aad9fb15ed7959f774c81a77299fdd0ddcf839d4"
 dependencies = [
  "Inflector",
  "base64 0.21.7",
@@ -5117,9 +5118,9 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67fd02dc01d0e7f06079625aaaa7de9ea86d757e16df3ec76cd6e162a91f23"
+checksum = "3a754a3c2265eb02e0c35aeaca96643951f03cee6b376afe12e0cf8860ffccd1"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -5132,9 +5133,9 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26db373e381b715773164fb9ae47a89f56bbb6fb50469b1b970134d5c6f6ce4d"
+checksum = "f44776bd685cc02e67ba264384acc12ef2931d01d1a9f851cb8cdbd3ce455b9e"
 dependencies = [
  "log",
  "rustc_version",
@@ -5148,9 +5149,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c579e4599523cefa128db4075d0fc7b1177434b23ac4f72140a394dd4b4f648"
+checksum = "25810970c91feb579bd3f67dca215fce971522e42bfd59696af89c5dfebd997c"
 dependencies = [
  "bincode",
  "log",
@@ -5170,9 +5171,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.18.8"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a78337e50d3ed0b8a6e521969c0e81dfa3649f4d718e88a7e9a0d04ca0d0e0"
+checksum = "7cbdf4249b6dfcbba7d84e2b53313698043f60f8e22ce48286e6fbe8a17c8d16"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.21.7",
@@ -5199,9 +5200,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d457cc2ba742c120492a64b7fa60e22c575e891f6b55039f4d736568fb112a3"
+checksum = "da5d083187e3b3f453e140f292c09186881da8a02a7b5e27f645ee26de3d9cc5"
 dependencies = [
  "byteorder",
  "combine",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3431,6 +3431,7 @@ dependencies = [
  "serde",
  "serde-this-or-that",
  "serde_json",
+ "smol_str",
  "soketto",
  "solana-account-decoder",
  "solana-client",
@@ -4459,6 +4460,16 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "smol_str"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
+dependencies = [
+ "borsh 1.4.0",
+ "serde",
+]
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ lazy_static = "1.4.0"
 toml_edit = "0.22.9"
 winnow = "0.6.5"
 proptest = "1.4.0"
+smol_str = {version="0.3.2", features=["serde"]}
 tracing = { version = "0.1.40", features = ["log"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 tracing-opentelemetry = "0.24.0"

--- a/src/agent/legacy_schedule.rs
+++ b/src/agent/legacy_schedule.rs
@@ -387,7 +387,7 @@ mod tests {
         let ok_datetimes = [
             NaiveDate::from_ymd_opt(2023, 11, 20)
                 .unwrap()
-                .and_time(MAX_TIME_INSTANT)
+                .and_time(MAX_TIME_INSTANT.clone())
                 .and_local_timezone(Tz::Europe__Amsterdam)
                 .unwrap(),
             NaiveDateTime::parse_from_str("2023-11-21 00:00", format)?
@@ -404,7 +404,7 @@ mod tests {
             // confused for Wednesday 00:00 which is open.
             NaiveDate::from_ymd_opt(2023, 11, 21)
                 .unwrap()
-                .and_time(MAX_TIME_INSTANT)
+                .and_time(MAX_TIME_INSTANT.clone())
                 .and_local_timezone(Tz::Europe__Amsterdam)
                 .unwrap(),
         ];

--- a/src/agent/legacy_schedule.rs
+++ b/src/agent/legacy_schedule.rs
@@ -384,7 +384,7 @@ mod tests {
             "Europe/Amsterdam,23:00-24:00,00:00-01:00,O,C,C,C,C".parse()?;
 
         let format = "%Y-%m-%d %H:%M";
-        let ok_datetimes = vec![
+        let ok_datetimes = [
             NaiveDate::from_ymd_opt(2023, 11, 20)
                 .unwrap()
                 .and_time(MAX_TIME_INSTANT.clone())
@@ -395,7 +395,7 @@ mod tests {
                 .unwrap(),
         ];
 
-        let bad_datetimes = vec![
+        let bad_datetimes = [
             // Start of Monday Nov 20th, must not be confused for MAX_TIME_INSTANT on that day
             NaiveDateTime::parse_from_str("2023-11-20 00:00", format)?
                 .and_local_timezone(Tz::Europe__Amsterdam)

--- a/src/agent/legacy_schedule.rs
+++ b/src/agent/legacy_schedule.rs
@@ -387,7 +387,7 @@ mod tests {
         let ok_datetimes = [
             NaiveDate::from_ymd_opt(2023, 11, 20)
                 .unwrap()
-                .and_time(MAX_TIME_INSTANT.clone())
+                .and_time(MAX_TIME_INSTANT)
                 .and_local_timezone(Tz::Europe__Amsterdam)
                 .unwrap(),
             NaiveDateTime::parse_from_str("2023-11-21 00:00", format)?
@@ -404,7 +404,7 @@ mod tests {
             // confused for Wednesday 00:00 which is open.
             NaiveDate::from_ymd_opt(2023, 11, 21)
                 .unwrap()
-                .and_time(MAX_TIME_INSTANT.clone())
+                .and_time(MAX_TIME_INSTANT)
                 .and_local_timezone(Tz::Europe__Amsterdam)
                 .unwrap(),
         ];

--- a/src/agent/legacy_schedule.rs
+++ b/src/agent/legacy_schedule.rs
@@ -327,7 +327,7 @@ mod tests {
 
         // Prepare UTC datetimes that fall before, within and after market hours
         let format = "%Y-%m-%d %H:%M";
-        let bad_datetimes_before = vec![
+        let bad_datetimes_before = [
             NaiveDateTime::parse_from_str("2023-11-20 04:30", format)?.and_utc(),
             NaiveDateTime::parse_from_str("2023-11-21 05:30", format)?.and_utc(),
             NaiveDateTime::parse_from_str("2023-11-22 06:30", format)?.and_utc(),
@@ -337,7 +337,7 @@ mod tests {
             NaiveDateTime::parse_from_str("2023-11-26 10:30", format)?.and_utc(),
         ];
 
-        let ok_datetimes = vec![
+        let ok_datetimes = [
             NaiveDateTime::parse_from_str("2023-11-20 05:30", format)?.and_utc(),
             NaiveDateTime::parse_from_str("2023-11-21 06:30", format)?.and_utc(),
             NaiveDateTime::parse_from_str("2023-11-22 07:30", format)?.and_utc(),
@@ -347,7 +347,7 @@ mod tests {
             NaiveDateTime::parse_from_str("2023-11-26 11:30", format)?.and_utc(),
         ];
 
-        let bad_datetimes_after = vec![
+        let bad_datetimes_after = [
             NaiveDateTime::parse_from_str("2023-11-20 06:30", format)?.and_utc(),
             NaiveDateTime::parse_from_str("2023-11-21 07:30", format)?.and_utc(),
             NaiveDateTime::parse_from_str("2023-11-22 08:30", format)?.and_utc(),
@@ -387,7 +387,7 @@ mod tests {
         let ok_datetimes = [
             NaiveDate::from_ymd_opt(2023, 11, 20)
                 .unwrap()
-                .and_time(MAX_TIME_INSTANT.clone())
+                .and_time(*MAX_TIME_INSTANT)
                 .and_local_timezone(Tz::Europe__Amsterdam)
                 .unwrap(),
             NaiveDateTime::parse_from_str("2023-11-21 00:00", format)?
@@ -404,7 +404,7 @@ mod tests {
             // confused for Wednesday 00:00 which is open.
             NaiveDate::from_ymd_opt(2023, 11, 21)
                 .unwrap()
-                .and_time(MAX_TIME_INSTANT.clone())
+                .and_time(*MAX_TIME_INSTANT)
                 .and_local_timezone(Tz::Europe__Amsterdam)
                 .unwrap(),
         ];

--- a/src/agent/market_schedule.rs
+++ b/src/agent/market_schedule.rs
@@ -47,7 +47,7 @@ const MAX_TIME_INSTANT: NaiveTime = NaiveTime::MIN
     .overflowing_sub_signed(Duration::nanoseconds(1))
     .0;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct MarketSchedule {
     pub timezone:        Tz,
     pub weekly_schedule: Vec<ScheduleDayKind>,
@@ -193,8 +193,9 @@ impl Display for HolidayDaySchedule {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Default, Clone, Debug, Eq, PartialEq)]
 pub enum ScheduleDayKind {
+    #[default]
     Open,
     Closed,
     TimeRanges(Vec<RangeInclusive<NaiveTime>>),
@@ -207,12 +208,6 @@ impl ScheduleDayKind {
             Self::Closed => false,
             Self::TimeRanges(ranges) => ranges.iter().any(|range| range.contains(&when_local)),
         }
-    }
-}
-
-impl Default for ScheduleDayKind {
-    fn default() -> Self {
-        Self::Open
     }
 }
 

--- a/src/agent/metrics.rs
+++ b/src/agent/metrics.rs
@@ -64,9 +64,7 @@ pub async fn spawn(addr: impl Into<SocketAddr> + 'static) {
             let mut buf = String::new();
             let response = encode(&mut buf, &&PROMETHEUS_REGISTRY.lock().await)
                 .map_err(|e| -> Box<dyn std::error::Error> { e.into() })
-                .and_then(|_| -> Result<_, Box<dyn std::error::Error>> {
-                    Ok(Box::new(reply::with_status(buf, StatusCode::OK)))
-                })
+                .map(|_| Box::new(reply::with_status(buf, StatusCode::OK)))
                 .unwrap_or_else(|e| {
                     tracing::error!(err = ?e, "Metrics: Could not gather metrics from registry");
                     Box::new(reply::with_status(

--- a/src/agent/metrics.rs
+++ b/src/agent/metrics.rs
@@ -115,7 +115,8 @@ impl ProductGlobalMetrics {
     }
 
     pub fn update(&self, product_key: &Pubkey, maybe_symbol: Option<SmolStr>) {
-        let symbol_string = maybe_symbol.map(|x| x.into())
+        let symbol_string = maybe_symbol
+            .map(|x| x.into())
             .unwrap_or(format!("unknown_{}", product_key));
 
         #[deny(unused_variables)]

--- a/src/agent/metrics.rs
+++ b/src/agent/metrics.rs
@@ -15,6 +15,7 @@ use {
         registry::Registry,
     },
     serde::Deserialize,
+    smol_str::SmolStr,
     solana_sdk::pubkey::Pubkey,
     std::{
         net::SocketAddr,
@@ -113,8 +114,9 @@ impl ProductGlobalMetrics {
         metrics
     }
 
-    pub fn update(&self, product_key: &Pubkey, maybe_symbol: Option<String>) {
-        let symbol_string = maybe_symbol.unwrap_or(format!("unknown_{}", product_key));
+    pub fn update(&self, product_key: &Pubkey, maybe_symbol: Option<SmolStr>) {
+        let symbol_string = maybe_symbol.map(|x| x.into())
+            .unwrap_or(format!("unknown_{}", product_key));
 
         #[deny(unused_variables)]
         let Self { update_count } = self;

--- a/src/agent/pyth.rs
+++ b/src/agent/pyth.rs
@@ -5,12 +5,13 @@ use {
     },
     std::collections::BTreeMap,
     std::sync::Arc,
+    smol_str::SmolStr,
 };
 
 pub mod rpc;
 
-pub type Pubkey = String;
-pub type Attrs = BTreeMap<String, String>;
+pub type Pubkey = SmolStr;
+pub type Attrs = BTreeMap<SmolStr, SmolStr>;
 
 pub type Price = i64;
 pub type Exponent = i64;
@@ -27,7 +28,7 @@ pub struct ProductAccountMetadata {
 #[derive(Serialize, Deserialize, Debug, Ord, PartialOrd, PartialEq, Eq)]
 pub struct PriceAccountMetadata {
     pub account:        Pubkey,
-    pub price_type:     String,
+    pub price_type:     SmolStr,
     pub price_exponent: Exponent,
 }
 
@@ -41,9 +42,9 @@ pub struct ProductAccount {
 #[derive(Serialize, Deserialize, Debug, Ord, PartialOrd, PartialEq, Eq)]
 pub struct PriceAccount {
     pub account:            Pubkey,
-    pub price_type:         String,
+    pub price_type:         SmolStr,
     pub price_exponent:     Exponent,
-    pub status:             String,
+    pub status:             SmolStr,
     pub price:              Price,
     pub conf:               Conf,
     pub twap:               Price,
@@ -59,7 +60,7 @@ pub struct PriceAccount {
 #[derive(Serialize, Deserialize, Debug, Ord, PartialOrd, PartialEq, Eq)]
 pub struct PublisherAccount {
     pub account: Pubkey,
-    pub status:  String,
+    pub status:  SmolStr,
     pub price:   Price,
     pub conf:    Conf,
     pub slot:    Slot,
@@ -82,7 +83,7 @@ pub type SubscriptionID = i64;
 pub struct PriceUpdate {
     pub price:      Price,
     pub conf:       Conf,
-    pub status:     String,
+    pub status:     SmolStr,
     pub valid_slot: Slot,
     pub pub_slot:   Slot,
 }

--- a/src/agent/pyth.rs
+++ b/src/agent/pyth.rs
@@ -3,9 +3,11 @@ use {
         Deserialize,
         Serialize,
     },
-    std::collections::BTreeMap,
-    std::sync::Arc,
     smol_str::SmolStr,
+    std::{
+        collections::BTreeMap,
+        sync::Arc,
+    },
 };
 
 pub mod rpc;
@@ -18,7 +20,7 @@ pub type Exponent = i64;
 pub type Conf = u64;
 pub type Slot = u64;
 
-#[derive(Serialize, Deserialize, Debug,  Ord, PartialOrd, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Ord, PartialOrd, PartialEq, Eq)]
 pub struct ProductAccountMetadata {
     pub account:   Pubkey,
     pub attr_dict: Attrs,

--- a/src/agent/pyth.rs
+++ b/src/agent/pyth.rs
@@ -4,6 +4,7 @@ use {
         Serialize,
     },
     std::collections::BTreeMap,
+    std::sync::Arc,
 };
 
 pub mod rpc;
@@ -16,28 +17,28 @@ pub type Exponent = i64;
 pub type Conf = u64;
 pub type Slot = u64;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug,  Ord, PartialOrd, PartialEq, Eq)]
 pub struct ProductAccountMetadata {
     pub account:   Pubkey,
     pub attr_dict: Attrs,
-    pub price:     Vec<PriceAccountMetadata>,
+    pub price:     Arc<[PriceAccountMetadata]>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Ord, PartialOrd, PartialEq, Eq)]
 pub struct PriceAccountMetadata {
     pub account:        Pubkey,
     pub price_type:     String,
     pub price_exponent: Exponent,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Ord, PartialOrd, PartialEq, Eq)]
 pub struct ProductAccount {
     pub account:        Pubkey,
     pub attr_dict:      Attrs,
-    pub price_accounts: Vec<PriceAccount>,
+    pub price_accounts: Arc<[PriceAccount]>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Ord, PartialOrd, PartialEq, Eq)]
 pub struct PriceAccount {
     pub account:            Pubkey,
     pub price_type:         String,
@@ -52,10 +53,10 @@ pub struct PriceAccount {
     pub prev_slot:          Slot,
     pub prev_price:         Price,
     pub prev_conf:          Conf,
-    pub publisher_accounts: Vec<PublisherAccount>,
+    pub publisher_accounts: Arc<[PublisherAccount]>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Ord, PartialOrd, PartialEq, Eq)]
 pub struct PublisherAccount {
     pub account: Pubkey,
     pub status:  String,
@@ -64,20 +65,20 @@ pub struct PublisherAccount {
     pub slot:    Slot,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Ord, PartialOrd, PartialEq, Eq)]
 pub struct NotifyPrice {
     pub subscription: SubscriptionID,
     pub result:       PriceUpdate,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Ord, PartialOrd, PartialEq, Eq)]
 pub struct NotifyPriceSched {
     pub subscription: SubscriptionID,
 }
 
 pub type SubscriptionID = i64;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Ord, PartialOrd, PartialEq, Eq)]
 pub struct PriceUpdate {
     pub price:      Price,
     pub conf:       Conf,

--- a/src/agent/state.rs
+++ b/src/agent/state.rs
@@ -247,7 +247,7 @@ mod tests {
                             ]
                             .map(|(k, v)| (k.to_string(), v.to_string())),
                         ),
-                        price_accounts: vec![
+                        price_accounts: [
                             solana_sdk::pubkey::Pubkey::from_str(
                                 "GVXRSBjFk6e6J3NbVPXohDJetcTjaeeuykUpbQF8UoMU",
                             )
@@ -260,7 +260,7 @@ mod tests {
                                 "2V7t5NaKY7aGkwytCWQgvUYZfEr9XMwNChhJEakTExk6",
                             )
                             .unwrap(),
-                        ],
+                        ].into(),
                     },
                 ),
                 (
@@ -280,7 +280,7 @@ mod tests {
                             ]
                             .map(|(k, v)| (k.to_string(), v.to_string())),
                         ),
-                        price_accounts: vec![
+                        price_accounts: [
                             solana_sdk::pubkey::Pubkey::from_str(
                                 "GG3FTE7xhc9Diy7dn9P6BWzoCrAEE4D3p5NBYrDAm5DD",
                             )
@@ -293,7 +293,7 @@ mod tests {
                                 "GKNcUmNacSJo4S2Kq3DuYRYRGw3sNUfJ4tyqd198t6vQ",
                             )
                             .unwrap(),
-                        ],
+                        ].into(),
                     },
                 ),
             ]),
@@ -372,7 +372,7 @@ mod tests {
                     ]
                     .map(|(k, v)| (k.to_string(), v.to_string())),
                 ),
-                price:     vec![
+                price: [
                     PriceAccountMetadata {
                         account:        "GG3FTE7xhc9Diy7dn9P6BWzoCrAEE4D3p5NBYrDAm5DD".to_string(),
                         price_type:     "price".to_string(),
@@ -388,7 +388,7 @@ mod tests {
                         price_type:     "price".to_string(),
                         price_exponent: 2,
                     },
-                ],
+                ].into(),
             },
             ProductAccountMetadata {
                 account:   "CkMrDWtmFJZcmAUC11qNaWymbXQKvnRx4cq1QudLav7t".to_string(),
@@ -403,7 +403,7 @@ mod tests {
                     ]
                     .map(|(k, v)| (k.to_string(), v.to_string())),
                 ),
-                price:     vec![
+                price: [
                     PriceAccountMetadata {
                         account:        "GVXRSBjFk6e6J3NbVPXohDJetcTjaeeuykUpbQF8UoMU".to_string(),
                         price_type:     "price".to_string(),
@@ -419,7 +419,7 @@ mod tests {
                         price_type:     "price".to_string(),
                         price_exponent: -6,
                     },
-                ],
+                ].into(),
             },
         ];
 
@@ -482,7 +482,7 @@ mod tests {
                         },
                         schedule:         Default::default(),
                         publish_interval: None,
-                        price_accounts:   vec![
+                        price_accounts:   [
                             solana_sdk::pubkey::Pubkey::from_str(
                                 "GVXRSBjFk6e6J3NbVPXohDJetcTjaeeuykUpbQF8UoMU",
                             )
@@ -495,7 +495,7 @@ mod tests {
                                 "2V7t5NaKY7aGkwytCWQgvUYZfEr9XMwNChhJEakTExk6",
                             )
                             .unwrap(),
-                        ],
+                        ].into(),
                     }
                     .into(),
                 ),
@@ -544,7 +544,7 @@ mod tests {
                         },
                         schedule:         Default::default(),
                         publish_interval: None,
-                        price_accounts:   vec![
+                        price_accounts:   [
                             solana_sdk::pubkey::Pubkey::from_str(
                                 "GG3FTE7xhc9Diy7dn9P6BWzoCrAEE4D3p5NBYrDAm5DD",
                             )
@@ -557,7 +557,7 @@ mod tests {
                                 "GKNcUmNacSJo4S2Kq3DuYRYRGw3sNUfJ4tyqd198t6vQ",
                             )
                             .unwrap(),
-                        ],
+                        ].into(),
                     }
                     .into(),
                 ),
@@ -1075,7 +1075,7 @@ mod tests {
                     ]
                     .map(|(k, v)| (k.to_string(), v.to_string())),
                 ),
-                price_accounts: vec![
+                price_accounts: [
                     pyth::PriceAccount {
                         account:            "GG3FTE7xhc9Diy7dn9P6BWzoCrAEE4D3p5NBYrDAm5DD"
                             .to_string(),
@@ -1091,7 +1091,7 @@ mod tests {
                         prev_slot:          791279274,
                         prev_price:         98272648,
                         prev_conf:          124986284,
-                        publisher_accounts: vec![
+                        publisher_accounts: [
                             PublisherAccount {
                                 account: "F42dQ3SMssashRsA4SRfwJxFkGKV1bE3TcmpkagX8vvX".to_string(),
                                 status:  "trading".to_string(),
@@ -1106,7 +1106,7 @@ mod tests {
                                 conf:    55896,
                                 slot:    32976,
                             },
-                        ],
+                        ].into(),
                     },
                     pyth::PriceAccount {
                         account:            "fTNjSfj5uW9e4CAMHzUcm65ftRNBxCN1gG5GS1mYfid"
@@ -1123,7 +1123,7 @@ mod tests {
                         prev_slot:          893734828,
                         prev_price:         13947294,
                         prev_conf:          349274938,
-                        publisher_accounts: vec![
+                        publisher_accounts: [
                             PublisherAccount {
                                 account: "8MMroLyuyxyeDRrzMNfpymC5RvmHtQiYooXX9bgeUJdM".to_string(),
                                 status:  "unknown".to_string(),
@@ -1138,7 +1138,7 @@ mod tests {
                                 conf:    8962196,
                                 slot:    301541,
                             },
-                        ],
+                        ].into(),
                     },
                     pyth::PriceAccount {
                         account:            "GKNcUmNacSJo4S2Kq3DuYRYRGw3sNUfJ4tyqd198t6vQ"
@@ -1155,15 +1155,15 @@ mod tests {
                         prev_slot:          8878456286,
                         prev_price:         24746384,
                         prev_conf:          6373957,
-                        publisher_accounts: vec![PublisherAccount {
+                        publisher_accounts: [PublisherAccount {
                             account: "33B2brfdz16kizEXeQvYzJXHiS1X95L8pfetuyntEiXg".to_string(),
                             status:  "trading".to_string(),
                             price:   61478,
                             conf:    312545,
                             slot:    302156,
-                        }],
+                        }].into(),
                     },
-                ],
+                ].into(),
             },
             pyth::ProductAccount {
                 account:        "CkMrDWtmFJZcmAUC11qNaWymbXQKvnRx4cq1QudLav7t".to_string(),
@@ -1178,7 +1178,7 @@ mod tests {
                     ]
                     .map(|(k, v)| (k.to_string(), v.to_string())),
                 ),
-                price_accounts: vec![
+                price_accounts: [
                     pyth::PriceAccount {
                         account:            "GVXRSBjFk6e6J3NbVPXohDJetcTjaeeuykUpbQF8UoMU"
                             .to_string(),
@@ -1194,7 +1194,7 @@ mod tests {
                         prev_slot:          172761778,
                         prev_price:         22691000,
                         prev_conf:          398674,
-                        publisher_accounts: vec![],
+                        publisher_accounts: [].into(),
                     },
                     pyth::PriceAccount {
                         account:            "3VQwtcntVQN1mj1MybQw8qK7Li3KNrrgNskSQwZAPGNr"
@@ -1211,13 +1211,13 @@ mod tests {
                         prev_slot:          1727612348,
                         prev_price:         746383678,
                         prev_conf:          757368,
-                        publisher_accounts: vec![PublisherAccount {
+                        publisher_accounts: [PublisherAccount {
                             account: "C9syZ2MoGUwbPyGEgiy8MxesaEEKLdJw8gnwx2jLK1cV".to_string(),
                             status:  "trading".to_string(),
                             price:   85698,
                             conf:    23645,
                             slot:    14765,
-                        }],
+                        }].into(),
                     },
                     pyth::PriceAccount {
                         account:            "2V7t5NaKY7aGkwytCWQgvUYZfEr9XMwNChhJEakTExk6"
@@ -1234,7 +1234,7 @@ mod tests {
                         prev_slot:          86484638,
                         prev_price:         28463947,
                         prev_conf:          83628234,
-                        publisher_accounts: vec![
+                        publisher_accounts: [
                             PublisherAccount {
                                 account: "DaMuPaW5dhGfRJaX7TzLWXd8hDCMJ5WA2XibJ12hjBNQ".to_string(),
                                 status:  "trading".to_string(),
@@ -1249,9 +1249,9 @@ mod tests {
                                 conf:    7456,
                                 slot:    865,
                             },
-                        ],
+                        ].into(),
                     },
-                ],
+                ].into(),
             },
         ];
 
@@ -1280,7 +1280,7 @@ mod tests {
         // Check that the result of the conversion to the Pythd API format is what we expected
         let expected = ProductAccount {
             account:        account.to_string(),
-            price_accounts: vec![
+            price_accounts: [
                 pyth::PriceAccount {
                     account:            "GVXRSBjFk6e6J3NbVPXohDJetcTjaeeuykUpbQF8UoMU".to_string(),
                     price_type:         "price".to_string(),
@@ -1295,7 +1295,7 @@ mod tests {
                     prev_slot:          172761778,
                     prev_price:         22691000,
                     prev_conf:          398674,
-                    publisher_accounts: vec![],
+                    publisher_accounts: [].into(),
                 },
                 pyth::PriceAccount {
                     account:            "3VQwtcntVQN1mj1MybQw8qK7Li3KNrrgNskSQwZAPGNr".to_string(),
@@ -1311,13 +1311,13 @@ mod tests {
                     prev_slot:          1727612348,
                     prev_price:         746383678,
                     prev_conf:          757368,
-                    publisher_accounts: vec![PublisherAccount {
+                    publisher_accounts: [PublisherAccount {
                         account: "C9syZ2MoGUwbPyGEgiy8MxesaEEKLdJw8gnwx2jLK1cV".to_string(),
                         status:  "trading".to_string(),
                         price:   85698,
                         conf:    23645,
                         slot:    14765,
-                    }],
+                    }].into(),
                 },
                 pyth::PriceAccount {
                     account:            "2V7t5NaKY7aGkwytCWQgvUYZfEr9XMwNChhJEakTExk6".to_string(),
@@ -1333,7 +1333,7 @@ mod tests {
                     prev_slot:          86484638,
                     prev_price:         28463947,
                     prev_conf:          83628234,
-                    publisher_accounts: vec![
+                    publisher_accounts: [
                         PublisherAccount {
                             account: "DaMuPaW5dhGfRJaX7TzLWXd8hDCMJ5WA2XibJ12hjBNQ".to_string(),
                             status:  "trading".to_string(),
@@ -1348,9 +1348,9 @@ mod tests {
                             conf:    7456,
                             slot:    865,
                         },
-                    ],
+                    ].into(),
                 },
-            ],
+            ].into(),
             attr_dict:      BTreeMap::from(
                 [
                     ("symbol", "Crypto.LTC/USD"),

--- a/src/agent/state.rs
+++ b/src/agent/state.rs
@@ -89,8 +89,8 @@ impl State {
             local_store:  local::Store::new(registry),
             keypairs:     keypairs::KeypairState::default(),
             prices:       api::PricesState::new(config.state.clone()),
-            oracle:       oracle::OracleState::new(),
             exporter:     exporter::ExporterState::new(),
+            oracle: oracle::OracleState::default(),
             transactions: transactions::TransactionsState::new(
                 config
                     .primary_network
@@ -109,8 +109,8 @@ impl State {
             local_store:  local::Store::new(registry),
             keypairs:     keypairs::KeypairState::default(),
             prices:       api::PricesState::new(config),
-            oracle:       oracle::OracleState::new(),
             exporter:     exporter::ExporterState::new(),
+            oracle: oracle::OracleState::default(),
             transactions: transactions::TransactionsState::new(100),
         }
     }

--- a/src/agent/state.rs
+++ b/src/agent/state.rs
@@ -496,7 +496,8 @@ mod tests {
                             )
                             .unwrap(),
                         ],
-                    },
+                    }
+                    .into(),
                 ),
                 (
                     solana_sdk::pubkey::Pubkey::from_str(
@@ -557,7 +558,8 @@ mod tests {
                             )
                             .unwrap(),
                         ],
-                    },
+                    }
+                    .into(),
                 ),
             ]),
             price_accounts:   HashMap::from([

--- a/src/agent/state.rs
+++ b/src/agent/state.rs
@@ -90,7 +90,7 @@ impl State {
             keypairs:     keypairs::KeypairState::default(),
             prices:       api::PricesState::new(config.state.clone()),
             exporter:     exporter::ExporterState::new(),
-            oracle: oracle::OracleState::default(),
+            oracle:       oracle::OracleState::default(),
             transactions: transactions::TransactionsState::new(
                 config
                     .primary_network
@@ -110,7 +110,7 @@ impl State {
             keypairs:     keypairs::KeypairState::default(),
             prices:       api::PricesState::new(config),
             exporter:     exporter::ExporterState::new(),
-            oracle: oracle::OracleState::default(),
+            oracle:       oracle::OracleState::default(),
             transactions: transactions::TransactionsState::new(100),
         }
     }
@@ -261,7 +261,8 @@ mod tests {
                                 "2V7t5NaKY7aGkwytCWQgvUYZfEr9XMwNChhJEakTExk6",
                             )
                             .unwrap(),
-                        ].into(),
+                        ]
+                        .into(),
                     },
                 ),
                 (
@@ -294,7 +295,8 @@ mod tests {
                                 "GKNcUmNacSJo4S2Kq3DuYRYRGw3sNUfJ4tyqd198t6vQ",
                             )
                             .unwrap(),
-                        ].into(),
+                        ]
+                        .into(),
                     },
                 ),
             ]),
@@ -373,7 +375,7 @@ mod tests {
                     ]
                     .map(|(k, v)| (k.into(), v.into())),
                 ),
-                price: [
+                price:     [
                     PriceAccountMetadata {
                         account:        "GG3FTE7xhc9Diy7dn9P6BWzoCrAEE4D3p5NBYrDAm5DD".into(),
                         price_type:     "price".into(),
@@ -389,7 +391,8 @@ mod tests {
                         price_type:     "price".into(),
                         price_exponent: 2,
                     },
-                ].into(),
+                ]
+                .into(),
             },
             ProductAccountMetadata {
                 account:   "CkMrDWtmFJZcmAUC11qNaWymbXQKvnRx4cq1QudLav7t".into(),
@@ -404,7 +407,7 @@ mod tests {
                     ]
                     .map(|(k, v)| (k.into(), v.into())),
                 ),
-                price: [
+                price:     [
                     PriceAccountMetadata {
                         account:        "GVXRSBjFk6e6J3NbVPXohDJetcTjaeeuykUpbQF8UoMU".into(),
                         price_type:     "price".into(),
@@ -420,7 +423,8 @@ mod tests {
                         price_type:     "price".into(),
                         price_exponent: -6,
                     },
-                ].into(),
+                ]
+                .into(),
             },
         ];
 
@@ -496,7 +500,8 @@ mod tests {
                                 "2V7t5NaKY7aGkwytCWQgvUYZfEr9XMwNChhJEakTExk6",
                             )
                             .unwrap(),
-                        ].into(),
+                        ]
+                        .into(),
                     }
                     .into(),
                 ),
@@ -558,7 +563,8 @@ mod tests {
                                 "GKNcUmNacSJo4S2Kq3DuYRYRGw3sNUfJ4tyqd198t6vQ",
                             )
                             .unwrap(),
-                        ].into(),
+                        ]
+                        .into(),
                     }
                     .into(),
                 ),
@@ -616,8 +622,7 @@ mod tests {
                         },
                         comp:           [PriceComp::default(); 32],
                         extended:       (),
-                    }))
-                    ,
+                    })),
                 ),
                 (
                     solana_sdk::pubkey::Pubkey::from_str(
@@ -1078,8 +1083,7 @@ mod tests {
                 ),
                 price_accounts: [
                     pyth::PriceAccount {
-                        account:            "GG3FTE7xhc9Diy7dn9P6BWzoCrAEE4D3p5NBYrDAm5DD"
-                            .into(),
+                        account:            "GG3FTE7xhc9Diy7dn9P6BWzoCrAEE4D3p5NBYrDAm5DD".into(),
                         price_type:         "price".into(),
                         price_exponent:     -9,
                         status:             "trading".into(),
@@ -1107,11 +1111,11 @@ mod tests {
                                 conf:    55896,
                                 slot:    32976,
                             },
-                        ].into(),
+                        ]
+                        .into(),
                     },
                     pyth::PriceAccount {
-                        account:            "fTNjSfj5uW9e4CAMHzUcm65ftRNBxCN1gG5GS1mYfid"
-                            .into(),
+                        account:            "fTNjSfj5uW9e4CAMHzUcm65ftRNBxCN1gG5GS1mYfid".into(),
                         price_type:         "price".into(),
                         price_exponent:     -6,
                         status:             "trading".into(),
@@ -1139,11 +1143,11 @@ mod tests {
                                 conf:    8962196,
                                 slot:    301541,
                             },
-                        ].into(),
+                        ]
+                        .into(),
                     },
                     pyth::PriceAccount {
-                        account:            "GKNcUmNacSJo4S2Kq3DuYRYRGw3sNUfJ4tyqd198t6vQ"
-                            .into(),
+                        account:            "GKNcUmNacSJo4S2Kq3DuYRYRGw3sNUfJ4tyqd198t6vQ".into(),
                         price_type:         "price".into(),
                         price_exponent:     2,
                         status:             "trading".into(),
@@ -1162,9 +1166,11 @@ mod tests {
                             price:   61478,
                             conf:    312545,
                             slot:    302156,
-                        }].into(),
+                        }]
+                        .into(),
                     },
-                ].into(),
+                ]
+                .into(),
             },
             pyth::ProductAccount {
                 account:        "CkMrDWtmFJZcmAUC11qNaWymbXQKvnRx4cq1QudLav7t".into(),
@@ -1181,8 +1187,7 @@ mod tests {
                 ),
                 price_accounts: [
                     pyth::PriceAccount {
-                        account:            "GVXRSBjFk6e6J3NbVPXohDJetcTjaeeuykUpbQF8UoMU"
-                            .into(),
+                        account:            "GVXRSBjFk6e6J3NbVPXohDJetcTjaeeuykUpbQF8UoMU".into(),
                         price_type:         "price".into(),
                         price_exponent:     -8,
                         status:             "unknown".into(),
@@ -1198,8 +1203,7 @@ mod tests {
                         publisher_accounts: [].into(),
                     },
                     pyth::PriceAccount {
-                        account:            "3VQwtcntVQN1mj1MybQw8qK7Li3KNrrgNskSQwZAPGNr"
-                            .into(),
+                        account:            "3VQwtcntVQN1mj1MybQw8qK7Li3KNrrgNskSQwZAPGNr".into(),
                         price_type:         "price".into(),
                         price_exponent:     -10,
                         status:             "unknown".into(),
@@ -1218,11 +1222,11 @@ mod tests {
                             price:   85698,
                             conf:    23645,
                             slot:    14765,
-                        }].into(),
+                        }]
+                        .into(),
                     },
                     pyth::PriceAccount {
-                        account:            "2V7t5NaKY7aGkwytCWQgvUYZfEr9XMwNChhJEakTExk6"
-                            .into(),
+                        account:            "2V7t5NaKY7aGkwytCWQgvUYZfEr9XMwNChhJEakTExk6".into(),
                         price_type:         "price".into(),
                         price_exponent:     -6,
                         status:             "trading".into(),
@@ -1250,9 +1254,11 @@ mod tests {
                                 conf:    7456,
                                 slot:    865,
                             },
-                        ].into(),
+                        ]
+                        .into(),
                     },
-                ].into(),
+                ]
+                .into(),
             },
         ];
 
@@ -1318,7 +1324,8 @@ mod tests {
                         price:   85698,
                         conf:    23645,
                         slot:    14765,
-                    }].into(),
+                    }]
+                    .into(),
                 },
                 pyth::PriceAccount {
                     account:            "2V7t5NaKY7aGkwytCWQgvUYZfEr9XMwNChhJEakTExk6".into(),
@@ -1349,9 +1356,11 @@ mod tests {
                             conf:    7456,
                             slot:    865,
                         },
-                    ].into(),
+                    ]
+                    .into(),
                 },
-            ].into(),
+            ]
+            .into(),
             attr_dict:      BTreeMap::from(
                 [
                     ("symbol", "Crypto.LTC/USD"),

--- a/src/agent/state.rs
+++ b/src/agent/state.rs
@@ -157,6 +157,7 @@ mod tests {
             Rational,
             SolanaPriceAccount,
         },
+        smol_str::ToSmolStr,
         std::{
             collections::{
                 BTreeMap,
@@ -245,7 +246,7 @@ mod tests {
                                 ("generic_symbol", "LTCUSD"),
                                 ("base", "LTC"),
                             ]
-                            .map(|(k, v)| (k.to_string(), v.to_string())),
+                            .map(|(k, v)| (k.into(), v.into())),
                         ),
                         price_accounts: [
                             solana_sdk::pubkey::Pubkey::from_str(
@@ -278,7 +279,7 @@ mod tests {
                                 ("generic_symbol", "ETHUSD"),
                                 ("base", "ETH"),
                             ]
-                            .map(|(k, v)| (k.to_string(), v.to_string())),
+                            .map(|(k, v)| (k.into(), v.into())),
                         ),
                         price_accounts: [
                             solana_sdk::pubkey::Pubkey::from_str(
@@ -360,7 +361,7 @@ mod tests {
         // Check that the result is what we expected
         let expected = vec![
             ProductAccountMetadata {
-                account:   "BjHoZWRxo9dgbR1NQhPyTiUs6xFiX6mGS4TMYvy3b2yc".to_string(),
+                account:   "BjHoZWRxo9dgbR1NQhPyTiUs6xFiX6mGS4TMYvy3b2yc".into(),
                 attr_dict: BTreeMap::from(
                     [
                         ("symbol", "Crypto.ETH/USD"),
@@ -370,28 +371,28 @@ mod tests {
                         ("generic_symbol", "ETHUSD"),
                         ("base", "ETH"),
                     ]
-                    .map(|(k, v)| (k.to_string(), v.to_string())),
+                    .map(|(k, v)| (k.into(), v.into())),
                 ),
                 price: [
                     PriceAccountMetadata {
-                        account:        "GG3FTE7xhc9Diy7dn9P6BWzoCrAEE4D3p5NBYrDAm5DD".to_string(),
-                        price_type:     "price".to_string(),
+                        account:        "GG3FTE7xhc9Diy7dn9P6BWzoCrAEE4D3p5NBYrDAm5DD".into(),
+                        price_type:     "price".into(),
                         price_exponent: -9,
                     },
                     PriceAccountMetadata {
-                        account:        "fTNjSfj5uW9e4CAMHzUcm65ftRNBxCN1gG5GS1mYfid".to_string(),
-                        price_type:     "price".to_string(),
+                        account:        "fTNjSfj5uW9e4CAMHzUcm65ftRNBxCN1gG5GS1mYfid".into(),
+                        price_type:     "price".into(),
                         price_exponent: -6,
                     },
                     PriceAccountMetadata {
-                        account:        "GKNcUmNacSJo4S2Kq3DuYRYRGw3sNUfJ4tyqd198t6vQ".to_string(),
-                        price_type:     "price".to_string(),
+                        account:        "GKNcUmNacSJo4S2Kq3DuYRYRGw3sNUfJ4tyqd198t6vQ".into(),
+                        price_type:     "price".into(),
                         price_exponent: 2,
                     },
                 ].into(),
             },
             ProductAccountMetadata {
-                account:   "CkMrDWtmFJZcmAUC11qNaWymbXQKvnRx4cq1QudLav7t".to_string(),
+                account:   "CkMrDWtmFJZcmAUC11qNaWymbXQKvnRx4cq1QudLav7t".into(),
                 attr_dict: BTreeMap::from(
                     [
                         ("symbol", "Crypto.LTC/USD"),
@@ -401,22 +402,22 @@ mod tests {
                         ("generic_symbol", "LTCUSD"),
                         ("base", "LTC"),
                     ]
-                    .map(|(k, v)| (k.to_string(), v.to_string())),
+                    .map(|(k, v)| (k.into(), v.into())),
                 ),
                 price: [
                     PriceAccountMetadata {
-                        account:        "GVXRSBjFk6e6J3NbVPXohDJetcTjaeeuykUpbQF8UoMU".to_string(),
-                        price_type:     "price".to_string(),
+                        account:        "GVXRSBjFk6e6J3NbVPXohDJetcTjaeeuykUpbQF8UoMU".into(),
+                        price_type:     "price".into(),
                         price_exponent: -8,
                     },
                     PriceAccountMetadata {
-                        account:        "3VQwtcntVQN1mj1MybQw8qK7Li3KNrrgNskSQwZAPGNr".to_string(),
-                        price_type:     "price".to_string(),
+                        account:        "3VQwtcntVQN1mj1MybQw8qK7Li3KNrrgNskSQwZAPGNr".into(),
+                        price_type:     "price".into(),
                         price_exponent: -10,
                     },
                     PriceAccountMetadata {
-                        account:        "2V7t5NaKY7aGkwytCWQgvUYZfEr9XMwNChhJEakTExk6".to_string(),
-                        price_type:     "price".to_string(),
+                        account:        "2V7t5NaKY7aGkwytCWQgvUYZfEr9XMwNChhJEakTExk6".into(),
+                        price_type:     "price".into(),
                         price_exponent: -6,
                     },
                 ].into(),
@@ -1063,7 +1064,7 @@ mod tests {
         // Check that the result of the conversion to the Pythd API format is what we expected
         let expected = vec![
             pyth::ProductAccount {
-                account:        "BjHoZWRxo9dgbR1NQhPyTiUs6xFiX6mGS4TMYvy3b2yc".to_string(),
+                account:        "BjHoZWRxo9dgbR1NQhPyTiUs6xFiX6mGS4TMYvy3b2yc".into(),
                 attr_dict:      BTreeMap::from(
                     [
                         ("symbol", "Crypto.ETH/USD"),
@@ -1073,15 +1074,15 @@ mod tests {
                         ("generic_symbol", "ETHUSD"),
                         ("base", "ETH"),
                     ]
-                    .map(|(k, v)| (k.to_string(), v.to_string())),
+                    .map(|(k, v)| (k.into(), v.into())),
                 ),
                 price_accounts: [
                     pyth::PriceAccount {
                         account:            "GG3FTE7xhc9Diy7dn9P6BWzoCrAEE4D3p5NBYrDAm5DD"
-                            .to_string(),
-                        price_type:         "price".to_string(),
+                            .into(),
+                        price_type:         "price".into(),
                         price_exponent:     -9,
-                        status:             "trading".to_string(),
+                        status:             "trading".into(),
                         price:              876384,
                         conf:               1349364,
                         twap:               863947389,
@@ -1093,15 +1094,15 @@ mod tests {
                         prev_conf:          124986284,
                         publisher_accounts: [
                             PublisherAccount {
-                                account: "F42dQ3SMssashRsA4SRfwJxFkGKV1bE3TcmpkagX8vvX".to_string(),
-                                status:  "trading".to_string(),
+                                account: "F42dQ3SMssashRsA4SRfwJxFkGKV1bE3TcmpkagX8vvX".into(),
+                                status:  "trading".into(),
                                 price:   54842,
                                 conf:    599755,
                                 slot:    1976465,
                             },
                             PublisherAccount {
-                                account: "AmmvowPnL2z1CVGR2fQNjgAmmJvRfpCKqpQMpTg9QsoG".to_string(),
-                                status:  "unknown".to_string(),
+                                account: "AmmvowPnL2z1CVGR2fQNjgAmmJvRfpCKqpQMpTg9QsoG".into(),
+                                status:  "unknown".into(),
                                 price:   65649,
                                 conf:    55896,
                                 slot:    32976,
@@ -1110,10 +1111,10 @@ mod tests {
                     },
                     pyth::PriceAccount {
                         account:            "fTNjSfj5uW9e4CAMHzUcm65ftRNBxCN1gG5GS1mYfid"
-                            .to_string(),
-                        price_type:         "price".to_string(),
+                            .into(),
+                        price_type:         "price".into(),
                         price_exponent:     -6,
-                        status:             "trading".to_string(),
+                        status:             "trading".into(),
                         price:              397492,
                         conf:               33487,
                         twap:               46280183,
@@ -1125,15 +1126,15 @@ mod tests {
                         prev_conf:          349274938,
                         publisher_accounts: [
                             PublisherAccount {
-                                account: "8MMroLyuyxyeDRrzMNfpymC5RvmHtQiYooXX9bgeUJdM".to_string(),
-                                status:  "unknown".to_string(),
+                                account: "8MMroLyuyxyeDRrzMNfpymC5RvmHtQiYooXX9bgeUJdM".into(),
+                                status:  "unknown".into(),
                                 price:   69854,
                                 conf:    732565,
                                 slot:    213654,
                             },
                             PublisherAccount {
-                                account: "GKNcUmNacSJo4S2Kq3DuYRYRGw3sNUfJ4tyqd198t6vQ".to_string(),
-                                status:  "trading".to_string(),
+                                account: "GKNcUmNacSJo4S2Kq3DuYRYRGw3sNUfJ4tyqd198t6vQ".into(),
+                                status:  "trading".into(),
                                 price:   3265,
                                 conf:    8962196,
                                 slot:    301541,
@@ -1142,10 +1143,10 @@ mod tests {
                     },
                     pyth::PriceAccount {
                         account:            "GKNcUmNacSJo4S2Kq3DuYRYRGw3sNUfJ4tyqd198t6vQ"
-                            .to_string(),
-                        price_type:         "price".to_string(),
+                            .into(),
+                        price_type:         "price".into(),
                         price_exponent:     2,
-                        status:             "trading".to_string(),
+                        status:             "trading".into(),
                         price:              836489,
                         conf:               6769467,
                         twap:               876979749,
@@ -1156,8 +1157,8 @@ mod tests {
                         prev_price:         24746384,
                         prev_conf:          6373957,
                         publisher_accounts: [PublisherAccount {
-                            account: "33B2brfdz16kizEXeQvYzJXHiS1X95L8pfetuyntEiXg".to_string(),
-                            status:  "trading".to_string(),
+                            account: "33B2brfdz16kizEXeQvYzJXHiS1X95L8pfetuyntEiXg".into(),
+                            status:  "trading".into(),
                             price:   61478,
                             conf:    312545,
                             slot:    302156,
@@ -1166,7 +1167,7 @@ mod tests {
                 ].into(),
             },
             pyth::ProductAccount {
-                account:        "CkMrDWtmFJZcmAUC11qNaWymbXQKvnRx4cq1QudLav7t".to_string(),
+                account:        "CkMrDWtmFJZcmAUC11qNaWymbXQKvnRx4cq1QudLav7t".into(),
                 attr_dict:      BTreeMap::from(
                     [
                         ("symbol", "Crypto.LTC/USD"),
@@ -1176,15 +1177,15 @@ mod tests {
                         ("generic_symbol", "LTCUSD"),
                         ("base", "LTC"),
                     ]
-                    .map(|(k, v)| (k.to_string(), v.to_string())),
+                    .map(|(k, v)| (k.into(), v.into())),
                 ),
                 price_accounts: [
                     pyth::PriceAccount {
                         account:            "GVXRSBjFk6e6J3NbVPXohDJetcTjaeeuykUpbQF8UoMU"
-                            .to_string(),
-                        price_type:         "price".to_string(),
+                            .into(),
+                        price_type:         "price".into(),
                         price_exponent:     -8,
-                        status:             "unknown".to_string(),
+                        status:             "unknown".into(),
                         price:              736382,
                         conf:               85623946,
                         twap:               5882210200,
@@ -1198,10 +1199,10 @@ mod tests {
                     },
                     pyth::PriceAccount {
                         account:            "3VQwtcntVQN1mj1MybQw8qK7Li3KNrrgNskSQwZAPGNr"
-                            .to_string(),
-                        price_type:         "price".to_string(),
+                            .into(),
+                        price_type:         "price".into(),
                         price_exponent:     -10,
-                        status:             "unknown".to_string(),
+                        status:             "unknown".into(),
                         price:              8474837,
                         conf:               27468478,
                         twap:               84739769,
@@ -1212,8 +1213,8 @@ mod tests {
                         prev_price:         746383678,
                         prev_conf:          757368,
                         publisher_accounts: [PublisherAccount {
-                            account: "C9syZ2MoGUwbPyGEgiy8MxesaEEKLdJw8gnwx2jLK1cV".to_string(),
-                            status:  "trading".to_string(),
+                            account: "C9syZ2MoGUwbPyGEgiy8MxesaEEKLdJw8gnwx2jLK1cV".into(),
+                            status:  "trading".into(),
                             price:   85698,
                             conf:    23645,
                             slot:    14765,
@@ -1221,10 +1222,10 @@ mod tests {
                     },
                     pyth::PriceAccount {
                         account:            "2V7t5NaKY7aGkwytCWQgvUYZfEr9XMwNChhJEakTExk6"
-                            .to_string(),
-                        price_type:         "price".to_string(),
+                            .into(),
+                        price_type:         "price".into(),
                         price_exponent:     -6,
-                        status:             "trading".to_string(),
+                        status:             "trading".into(),
                         price:              8254826,
                         conf:               6385638,
                         twap:               12895763,
@@ -1236,15 +1237,15 @@ mod tests {
                         prev_conf:          83628234,
                         publisher_accounts: [
                             PublisherAccount {
-                                account: "DaMuPaW5dhGfRJaX7TzLWXd8hDCMJ5WA2XibJ12hjBNQ".to_string(),
-                                status:  "trading".to_string(),
+                                account: "DaMuPaW5dhGfRJaX7TzLWXd8hDCMJ5WA2XibJ12hjBNQ".into(),
+                                status:  "trading".into(),
                                 price:   8251,
                                 conf:    7653,
                                 slot:    365545,
                             },
                             PublisherAccount {
-                                account: "FHuAg9vpDGeyhZn4W4FRcCzx6MC18r4bF9fTVJqeMijU".to_string(),
-                                status:  "unknown".to_string(),
+                                account: "FHuAg9vpDGeyhZn4W4FRcCzx6MC18r4bF9fTVJqeMijU".into(),
+                                status:  "unknown".into(),
                                 price:   39865,
                                 conf:    7456,
                                 slot:    865,
@@ -1279,13 +1280,13 @@ mod tests {
 
         // Check that the result of the conversion to the Pythd API format is what we expected
         let expected = ProductAccount {
-            account:        account.to_string(),
+            account:        account.to_smolstr(),
             price_accounts: [
                 pyth::PriceAccount {
-                    account:            "GVXRSBjFk6e6J3NbVPXohDJetcTjaeeuykUpbQF8UoMU".to_string(),
-                    price_type:         "price".to_string(),
+                    account:            "GVXRSBjFk6e6J3NbVPXohDJetcTjaeeuykUpbQF8UoMU".into(),
+                    price_type:         "price".into(),
                     price_exponent:     -8,
-                    status:             "unknown".to_string(),
+                    status:             "unknown".into(),
                     price:              736382,
                     conf:               85623946,
                     twap:               5882210200,
@@ -1298,10 +1299,10 @@ mod tests {
                     publisher_accounts: [].into(),
                 },
                 pyth::PriceAccount {
-                    account:            "3VQwtcntVQN1mj1MybQw8qK7Li3KNrrgNskSQwZAPGNr".to_string(),
-                    price_type:         "price".to_string(),
+                    account:            "3VQwtcntVQN1mj1MybQw8qK7Li3KNrrgNskSQwZAPGNr".into(),
+                    price_type:         "price".into(),
                     price_exponent:     -10,
-                    status:             "unknown".to_string(),
+                    status:             "unknown".into(),
                     price:              8474837,
                     conf:               27468478,
                     twap:               84739769,
@@ -1312,18 +1313,18 @@ mod tests {
                     prev_price:         746383678,
                     prev_conf:          757368,
                     publisher_accounts: [PublisherAccount {
-                        account: "C9syZ2MoGUwbPyGEgiy8MxesaEEKLdJw8gnwx2jLK1cV".to_string(),
-                        status:  "trading".to_string(),
+                        account: "C9syZ2MoGUwbPyGEgiy8MxesaEEKLdJw8gnwx2jLK1cV".into(),
+                        status:  "trading".into(),
                         price:   85698,
                         conf:    23645,
                         slot:    14765,
                     }].into(),
                 },
                 pyth::PriceAccount {
-                    account:            "2V7t5NaKY7aGkwytCWQgvUYZfEr9XMwNChhJEakTExk6".to_string(),
-                    price_type:         "price".to_string(),
+                    account:            "2V7t5NaKY7aGkwytCWQgvUYZfEr9XMwNChhJEakTExk6".into(),
+                    price_type:         "price".into(),
                     price_exponent:     -6,
-                    status:             "trading".to_string(),
+                    status:             "trading".into(),
                     price:              8254826,
                     conf:               6385638,
                     twap:               12895763,
@@ -1335,15 +1336,15 @@ mod tests {
                     prev_conf:          83628234,
                     publisher_accounts: [
                         PublisherAccount {
-                            account: "DaMuPaW5dhGfRJaX7TzLWXd8hDCMJ5WA2XibJ12hjBNQ".to_string(),
-                            status:  "trading".to_string(),
+                            account: "DaMuPaW5dhGfRJaX7TzLWXd8hDCMJ5WA2XibJ12hjBNQ".into(),
+                            status:  "trading".into(),
                             price:   8251,
                             conf:    7653,
                             slot:    365545,
                         },
                         PublisherAccount {
-                            account: "FHuAg9vpDGeyhZn4W4FRcCzx6MC18r4bF9fTVJqeMijU".to_string(),
-                            status:  "unknown".to_string(),
+                            account: "FHuAg9vpDGeyhZn4W4FRcCzx6MC18r4bF9fTVJqeMijU".into(),
+                            status:  "unknown".into(),
                             price:   39865,
                             conf:    7456,
                             slot:    865,
@@ -1360,7 +1361,7 @@ mod tests {
                     ("generic_symbol", "LTCUSD"),
                     ("base", "LTC"),
                 ]
-                .map(|(k, v)| (k.to_string(), v.to_string())),
+                .map(|(k, v)| (k.into(), v.into())),
             ),
         };
 
@@ -1381,7 +1382,7 @@ mod tests {
         let conf = 98754;
         state
             .state
-            .update_local_price(&account, price, conf, "trading".to_string())
+            .update_local_price(&account, price, conf, "trading".into())
             .await
             .unwrap();
 
@@ -1482,7 +1483,7 @@ mod tests {
                 result:       PriceUpdate {
                     price:      test_price.agg.price,
                     conf:       test_price.agg.conf,
-                    status:     "trading".to_string(),
+                    status:     "trading".into(),
                     valid_slot: test_price.valid_slot,
                     pub_slot:   test_price.agg.pub_slot,
                 },

--- a/src/agent/state.rs
+++ b/src/agent/state.rs
@@ -568,7 +568,7 @@ mod tests {
                         "GVXRSBjFk6e6J3NbVPXohDJetcTjaeeuykUpbQF8UoMU",
                     )
                     .unwrap(),
-                    SolanaPriceAccount {
+                    Arc::new(PriceEntry::from(SolanaPriceAccount {
                         magic:          0xa1b2c3d4,
                         ver:            7,
                         atype:          9,
@@ -615,15 +615,15 @@ mod tests {
                         },
                         comp:           [PriceComp::default(); 32],
                         extended:       (),
-                    }
-                    .into(),
+                    }))
+                    ,
                 ),
                 (
                     solana_sdk::pubkey::Pubkey::from_str(
                         "3VQwtcntVQN1mj1MybQw8qK7Li3KNrrgNskSQwZAPGNr",
                     )
                     .unwrap(),
-                    SolanaPriceAccount {
+                    Arc::new(PriceEntry::from(SolanaPriceAccount {
                         magic:          0xa1b2c3d4,
                         ver:            6,
                         atype:          4,
@@ -689,15 +689,14 @@ mod tests {
                             },
                         }]),
                         extended:       (),
-                    }
-                    .into(),
+                    })),
                 ),
                 (
                     solana_sdk::pubkey::Pubkey::from_str(
                         "2V7t5NaKY7aGkwytCWQgvUYZfEr9XMwNChhJEakTExk6",
                     )
                     .unwrap(),
-                    SolanaPriceAccount {
+                    Arc::new(PriceEntry::from(SolanaPriceAccount {
                         magic:          0xa1b2c3d4,
                         ver:            7,
                         atype:          6,
@@ -785,15 +784,14 @@ mod tests {
                             },
                         ]),
                         extended:       (),
-                    }
-                    .into(),
+                    })),
                 ),
                 (
                     solana_sdk::pubkey::Pubkey::from_str(
                         "GG3FTE7xhc9Diy7dn9P6BWzoCrAEE4D3p5NBYrDAm5DD",
                     )
                     .unwrap(),
-                    SolanaPriceAccount {
+                    Arc::new(PriceEntry::from(SolanaPriceAccount {
                         magic:          0xa1b2c3d4,
                         ver:            6,
                         atype:          6,
@@ -878,15 +876,14 @@ mod tests {
                             },
                         ]),
                         extended:       (),
-                    }
-                    .into(),
+                    })),
                 ),
                 (
                     solana_sdk::pubkey::Pubkey::from_str(
                         "fTNjSfj5uW9e4CAMHzUcm65ftRNBxCN1gG5GS1mYfid",
                     )
                     .unwrap(),
-                    SolanaPriceAccount {
+                    Arc::new(PriceEntry::from(SolanaPriceAccount {
                         magic:          0xa1b2c3d4,
                         ver:            8,
                         atype:          4,
@@ -974,15 +971,14 @@ mod tests {
                             },
                         ]),
                         extended:       (),
-                    }
-                    .into(),
+                    })),
                 ),
                 (
                     solana_sdk::pubkey::Pubkey::from_str(
                         "GKNcUmNacSJo4S2Kq3DuYRYRGw3sNUfJ4tyqd198t6vQ",
                     )
                     .unwrap(),
-                    SolanaPriceAccount {
+                    Arc::new(PriceEntry::from(SolanaPriceAccount {
                         magic:          0xa1b2c3d4,
                         ver:            6,
                         atype:          3,
@@ -1045,8 +1041,7 @@ mod tests {
                             },
                         }]),
                         extended:       (),
-                    }
-                    .into(),
+                    })),
                 ),
             ]),
         }
@@ -1384,7 +1379,7 @@ mod tests {
             .unwrap();
         let price = 2365;
         let conf = 98754;
-        let _ = state
+        state
             .state
             .update_local_price(&account, price, conf, "trading".to_string())
             .await
@@ -1466,7 +1461,7 @@ mod tests {
         }
         .into();
 
-        let _ = state
+        state
             .state
             .update_global_price(
                 Network::Primary,

--- a/src/agent/state/api.rs
+++ b/src/agent/state/api.rs
@@ -44,6 +44,9 @@ use {
         PriceComp,
         PriceStatus,
     },
+    smol_str::{
+        SmolStr,
+        ToSmolStr},
     std::{
         collections::HashMap,
         sync::atomic::AtomicI64,
@@ -57,7 +60,7 @@ use {
 };
 
 // TODO: implement Display on PriceStatus and then just call PriceStatus::to_string
-fn price_status_to_str(price_status: PriceStatus) -> String {
+fn price_status_to_str(price_status: PriceStatus) -> SmolStr {
     match price_status {
         PriceStatus::Unknown => "unknown",
         PriceStatus::Trading => "trading",
@@ -65,7 +68,7 @@ fn price_status_to_str(price_status: PriceStatus) -> String {
         PriceStatus::Auction => "auction",
         PriceStatus::Ignored => "ignored",
     }
-    .to_string()
+    .into()
 }
 
 fn solana_product_account_to_pythd_api_product_account(
@@ -90,12 +93,12 @@ fn solana_product_account_to_pythd_api_product_account(
 
     // Create the product account metadata struct
     ProductAccount {
-        account: product_account_key.to_string(),
+        account: product_account_key.to_smolstr(),
         attr_dict: product_account
             .account_data
             .iter()
             .filter(|(key, val)| !key.is_empty() && !val.is_empty())
-            .map(|(key, val)| (key.to_owned(), val.to_owned()))
+            .map(|(key, val)| (key.into(), val.into()))
             .collect(),
         price_accounts,
     }
@@ -106,8 +109,8 @@ fn solana_price_account_to_pythd_api_price_account(
     price_account: &PriceEntry,
 ) -> PriceAccount {
     PriceAccount {
-        account:            price_account_key.to_string(),
-        price_type:         "price".to_string(),
+        account:            price_account_key.to_smolstr(),
+        price_type:         "price".into(),
         price_exponent:     price_account.expo as i64,
         status:             price_status_to_str(price_account.agg.status),
         price:              price_account.agg.price,
@@ -124,7 +127,7 @@ fn solana_price_account_to_pythd_api_price_account(
             .iter()
             .filter(|comp| *comp != &PriceComp::default())
             .map(|comp| PublisherAccount {
-                account: comp.publisher.to_string(),
+                account: comp.publisher.to_smolstr(),
                 status:  price_status_to_str(comp.agg.status),
                 price:   comp.agg.price,
                 conf:    comp.agg.conf,
@@ -222,15 +225,15 @@ where
                         .map(|acc| (price_account_key, acc))
                 })
                 .map(|(price_account_key, price_account)| PriceAccountMetadata {
-                    account:        price_account_key.to_string(),
-                    price_type:     "price".to_owned(),
+                    account:        price_account_key.to_smolstr(),
+                    price_type:     "price".into(),
                     price_exponent: price_account.expo as i64,
                 })
                 .collect();
 
             // Create the product account metadata struct
             result.push(ProductAccountMetadata {
-                account:   product_account_key.to_string(),
+                account:   product_account_key.to_smolstr(),
                 attr_dict: product_account.attr_dict,
                 price:     price_accounts_metadata,
             })

--- a/src/agent/state/api.rs
+++ b/src/agent/state/api.rs
@@ -46,7 +46,8 @@ use {
     },
     smol_str::{
         SmolStr,
-        ToSmolStr},
+        ToSmolStr,
+    },
     std::{
         collections::HashMap,
         sync::atomic::AtomicI64,

--- a/src/agent/state/exporter.rs
+++ b/src/agent/state/exporter.rs
@@ -215,7 +215,7 @@ where
                 }
             })
             .filter_map(|(feed_id, info)| {
-                let key_from_id = Pubkey::from(feed_id.clone().to_bytes());
+                let key_from_id = Pubkey::from(feed_id.to_bytes());
                 if let Some(publisher_permission) = our_prices.get(&key_from_id) {
                     let now_utc = Utc::now();
                     let can_publish = publisher_permission.schedule.can_publish_at(&now_utc);
@@ -257,7 +257,7 @@ where
                     }
                 };
 
-                let key_from_id = Pubkey::from((update.feed_id).clone().to_bytes());
+                let key_from_id = Pubkey::from(update.feed_id.to_bytes());
                 let publisher_metadata = match our_prices.get(&key_from_id) {
                     Some(metadata) => metadata,
                     None => {
@@ -515,7 +515,7 @@ where
         ));
 
         for update in batch {
-            batch_state.insert(update.feed_id, update.info.clone());
+            batch_state.insert(update.feed_id, update.info);
         }
     }
 
@@ -579,11 +579,10 @@ where
     let local_store_contents = LocalStore::get_all_price_infos(&*state).await;
     for update in batch {
         let mut update = update.clone();
-        update.info = local_store_contents
+        update.info = *local_store_contents
             .get(&update.feed_id)
             .ok_or_else(|| anyhow!("price identifier not found in local store"))
-            .with_context(|| update.feed_id.to_string())?
-            .clone();
+            .with_context(|| update.feed_id.to_string())?;
 
         let stale_price = now > update.info.timestamp + staleness_threshold;
         if stale_price {

--- a/src/agent/state/global.rs
+++ b/src/agent/state/global.rs
@@ -28,6 +28,7 @@ use {
         HashSet,
     }, sync::Arc},
     tokio::sync::RwLock,
+    smol_str::SmolStr,
 };
 
 /// AllAccountsData contains the full data for the price and product accounts, sourced
@@ -51,7 +52,7 @@ pub struct AllAccountsMetadata {
 #[derive(Debug, Clone, Default)]
 pub struct ProductAccountMetadata {
     /// Attribute dictionary
-    pub attr_dict:      BTreeMap<String, String>,
+    pub attr_dict:      BTreeMap<SmolStr, SmolStr>,
     /// Price accounts associated with this product
     pub price_accounts: Vec<Pubkey>,
 }
@@ -62,7 +63,7 @@ impl From<&ProductEntry> for ProductAccountMetadata {
             attr_dict: product_account
                 .account_data
                 .iter()
-                .map(|(key, val)| (key.to_owned(), val.to_owned()))
+                .map(|(key, val)| (key.into(), val.into()))
                 .collect(),
             price_accounts: product_account.price_accounts.clone(),
         }

--- a/src/agent/state/global.rs
+++ b/src/agent/state/global.rs
@@ -21,14 +21,17 @@ use {
         Result,
     },
     prometheus_client::registry::Registry,
-    solana_sdk::pubkey::Pubkey,
-    std::{collections::{
-        BTreeMap,
-        HashMap,
-        HashSet,
-    }, sync::Arc},
-    tokio::sync::RwLock,
     smol_str::SmolStr,
+    solana_sdk::pubkey::Pubkey,
+    std::{
+        collections::{
+            BTreeMap,
+            HashMap,
+            HashSet,
+        },
+        sync::Arc,
+    },
+    tokio::sync::RwLock,
 };
 
 /// AllAccountsData contains the full data for the price and product accounts, sourced
@@ -36,7 +39,7 @@ use {
 #[derive(Debug, Clone, Default)]
 pub struct AllAccountsData {
     pub product_accounts: HashMap<Pubkey, Arc<ProductEntry>>,
-    pub price_accounts: HashMap<Pubkey, Arc<PriceEntry>>,
+    pub price_accounts:   HashMap<Pubkey, Arc<PriceEntry>>,
 }
 
 /// AllAccountsMetadata contains the metadata for all the price and product accounts.
@@ -60,7 +63,7 @@ pub struct ProductAccountMetadata {
 impl From<&ProductEntry> for ProductAccountMetadata {
     fn from(product_account: &ProductEntry) -> Self {
         ProductAccountMetadata {
-            attr_dict: product_account
+            attr_dict:      product_account
                 .account_data
                 .iter()
                 .map(|(key, val)| (key.into(), val.into()))
@@ -89,11 +92,11 @@ impl From<&PriceEntry> for PriceAccountMetadata {
 pub enum Update {
     ProductAccountUpdate {
         account_key: Pubkey,
-        account: Arc<ProductEntry>,
+        account:     Arc<ProductEntry>,
     },
     PriceAccountUpdate {
         account_key: Pubkey,
-        account: Arc<PriceEntry>,
+        account:     Arc<PriceEntry>,
     },
 }
 

--- a/src/agent/state/global.rs
+++ b/src/agent/state/global.rs
@@ -22,11 +22,11 @@ use {
     },
     prometheus_client::registry::Registry,
     solana_sdk::pubkey::Pubkey,
-    std::collections::{
+    std::{collections::{
         BTreeMap,
         HashMap,
         HashSet,
-    },
+    }, sync::Arc},
     tokio::sync::RwLock,
 };
 

--- a/src/agent/state/local.rs
+++ b/src/agent/state/local.rs
@@ -16,7 +16,7 @@ use {
     tokio::sync::RwLock,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct PriceInfo {
     pub status:    PriceStatus,
     pub price:     i64,

--- a/src/agent/state/oracle.rs
+++ b/src/agent/state/oracle.rs
@@ -398,15 +398,17 @@ async fn fetch_publisher_buffer_key(
     Ok(config.buffer_account.into())
 }
 
+type ProductAndPriceAccounts = (
+    HashMap<Pubkey, Arc<ProductEntry>>,
+    HashMap<Pubkey, Arc<PriceEntry>>,
+);
+
 #[instrument(skip(rpc_client))]
 async fn fetch_product_and_price_accounts(
     rpc_client: &RpcClient,
     oracle_program_key: Pubkey,
     max_lookup_batch_size: usize,
-) -> Result<(
-    HashMap<Pubkey, Arc<ProductEntry>>,
-    HashMap<Pubkey, Arc<PriceEntry>>,
-)> {
+) -> Result<ProductAndPriceAccounts> {
     let mut product_entries = HashMap::new();
     let mut price_entries = HashMap::new();
 

--- a/src/agent/state/oracle.rs
+++ b/src/agent/state/oracle.rs
@@ -173,16 +173,9 @@ impl Default for Config {
     }
 }
 
+#[derive(Default)]
 pub struct OracleState {
     data: RwLock<Data>,
-}
-
-impl OracleState {
-    pub fn new() -> Self {
-        Self {
-            data: Default::default(),
-        }
-    }
 }
 
 #[async_trait::async_trait]

--- a/src/agent/state/oracle.rs
+++ b/src/agent/state/oracle.rs
@@ -43,11 +43,11 @@ use {
             HashMap,
             HashSet,
         },
+        sync::Arc,
         time::Duration,
     },
     tokio::sync::RwLock,
     tracing::instrument,
-    std::sync::Arc,
 };
 
 #[derive(Debug)]
@@ -131,8 +131,8 @@ impl std::ops::Deref for PriceEntry {
 
 #[derive(Default, Debug)]
 pub struct Data {
-    pub product_accounts: HashMap<Pubkey, Arc<ProductEntry>>,
-    pub price_accounts: HashMap<Pubkey, Arc<PriceEntry>>,
+    pub product_accounts:      HashMap<Pubkey, Arc<ProductEntry>>,
+    pub price_accounts:        HashMap<Pubkey, Arc<PriceEntry>>,
     /// publisher => {their permissioned price accounts => price publishing metadata}
     pub publisher_permissions: HashMap<Pubkey, HashMap<Pubkey, PricePublishingMetadata>>,
     pub publisher_buffer_key:  Option<Pubkey>,
@@ -247,7 +247,7 @@ where
             network,
             &Update::PriceAccountUpdate {
                 account_key: *account_key,
-                account: Arc::new(price_entry),
+                account:     Arc::new(price_entry),
             },
         )
         .await?;
@@ -370,7 +370,7 @@ where
                 network,
                 &Update::PriceAccountUpdate {
                     account_key: *price_account_key,
-                    account: price_account.clone(),
+                    account:     price_account.clone(),
                 },
             )
             .await

--- a/src/agent/state/oracle.rs
+++ b/src/agent/state/oracle.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 #[allow(deprecated)]
 use crate::agent::legacy_schedule::LegacySchedule;
 use {
@@ -49,6 +47,7 @@ use {
     },
     tokio::sync::RwLock,
     tracing::instrument,
+    std::sync::Arc,
 };
 
 #[derive(Debug)]

--- a/src/agent/state/oracle.rs
+++ b/src/agent/state/oracle.rs
@@ -51,7 +51,7 @@ use {
     tracing::instrument,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ProductEntry {
     pub account_data:     pyth_sdk_solana::state::ProductAccount,
     pub schedule:         MarketSchedule,
@@ -130,7 +130,7 @@ impl std::ops::Deref for PriceEntry {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug)]
 pub struct Data {
     pub product_accounts: HashMap<Pubkey, Arc<ProductEntry>>,
     pub price_accounts: HashMap<Pubkey, Arc<PriceEntry>>,
@@ -485,7 +485,7 @@ async fn fetch_product_and_price_accounts(
             ProductEntry {
                 account_data: *product,
                 schedule: market_schedule.unwrap_or_else(|| legacy_schedule.into()),
-                price_accounts: vec![],
+                price_accounts: [].into(),
                 publish_interval,
             },
         );


### PR DESCRIPTION
- Using `Arc<PriceEntry>` and `Arc<ProductEntry>` in `UpdateProductAccountUpdate` and `Update::PriceAccountUpdate` to decrease the size difference between the variants.
- Using `Arc<PriceEntry>` and `Arc<ProductEntry>` in maps to reduce clone time by only cloning the reference
- Replacing imutable strings by `SmolStr`
- Remove unnecessary `clone` on `Copy`
- Fix audit issue:
```sh
Crate:     rustls                                                                                               
Version:   0.21.10                                                                                              
Title:     `rustls::ConnectionCommon::complete_io` could fall into an infinite loop based on network input      
Date:      2024-04-19                                                                                           
ID:        RUSTSEC-2024-0336                                                                                    
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0336                                                     
Severity:  7.5 (high)                                                                                           
Solution:  Upgrade to >=0.23.5 OR >=0.22.4, <0.23.0 OR >=0.21.11, <0.22.0
```