### PR TITLE
fix: handle product attributes properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "2.12.2"
+version = "2.12.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3476,9 +3476,9 @@ dependencies = [
 
 [[package]]
 name = "pyth-sdk-solana"
-version = "0.10.1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f913de6eb29d8def199af3beaee645e84c5281327d58777eff3fdd9f1d37105"
+checksum = "5a1875ce0bee6b18af4a9700ae8e514f1dd093c29aa3400e2a40e96421adcdb5"
 dependencies = [
  "borsh 0.10.3",
  "borsh-derive 0.10.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "2.12.2"
+version = "2.12.3"
 edition = "2021"
 
 [[bin]]
@@ -24,7 +24,7 @@ chrono = "0.4.37"
 chrono-tz = "0.8.6"
 parking_lot = "0.12.1"
 pyth-sdk = "0.8.0"
-pyth-sdk-solana = "0.10.0"
+pyth-sdk-solana = "0.10.4"
 solana-account-decoder = "1.18.8"
 solana-client = "1.18.8"
 solana-sdk = "1.18.8"


### PR DESCRIPTION
use the new pyth sdk-solana that contains a bug fix for iterating over product attributes. the older version might go beyond the size of the attributes (and show old attribute residuals instead).

We got a report that symbol is the old symbol on agent and it looked impossible because the metadata was updated everywhere. What was happening was that on `Crypto.Index.CRT/USD` token, `symbol` is defined two times if you look at the raw account data below and the older sdk would parse all the account regardless of the size. [This](https://github.com/pyth-network/pyth-sdk-rs/pull/123) PR has fixed it.

```
0000:   d4 c3 b2 a1  02 00 00 00  02 00 00 00  09 01 00 00   ................
0010:   b2 fb 54 96  6d 4d 30 af  bb 77 cc 9d  ce 9d 43 c5   ..T.mM0..w....C.
0020:   2f 0f 57 5e  7d 41 dc ab  6f f3 db fe  15 ad 45 59   /.W^}A..o.....EY
0030:   06 73 79 6d  62 6f 6c 14  43 72 79 70  74 6f 2e 49   .symbol.Crypto.I
0040:   6e 64 65 78  2e 43 52 54  2f 55 53 44  0a 61 73 73   ndex.CRT/USD.ass
0050:   65 74 5f 74  79 70 65 0c  43 72 79 70  74 6f 20 49   et_type.Crypto I
0060:   6e 64 65 78  04 62 61 73  65 03 43 52  54 0b 64 65   ndex.base.CRT.de
0070:   73 63 72 69  70 74 69 6f  6e 26 43 41  52 52 4f 54   scription&CARROT
0080:   20 59 49 45  4c 44 20 42  45 41 52 49  4e 47 20 54    YIELD BEARING T
0090:   4f 4b 45 4e  20 2f 20 55  53 20 44 4f  4c 4c 41 52   OKEN / US DOLLAR
00a0:   0e 64 69 73  70 6c 61 79  5f 73 79 6d  62 6f 6c 07   .display_symbol.
00b0:   43 52 54 2f  55 53 44 0e  67 65 6e 65  72 69 63 5f   CRT/USD.generic_
00c0:   73 79 6d 62  6f 6c 06 43  52 54 55 53  44 0e 71 75   symbol.CRTUSD.qu
00d0:   6f 74 65 5f  63 75 72 72  65 6e 63 79  03 55 53 44   ote_currency.USD
00e0:   08 73 63 68  65 64 75 6c  65 1f 41 6d  65 72 69 63   .schedule.Americ
00f0:   61 2f 4e 65  77 5f 59 6f  72 6b 3b 4f  2c 4f 2c 4f   a/New_York;O,O,O
0100:   2c 4f 2c 4f  2c 4f 2c 4f  3b 0e 71 75  6f 74 65 5f   ,O,O,O,O;.quote_
0110:   63 75 72 72  65 6e 63 79  03 55 53 44  08 73 63 68   currency.USD.sch
0120:   65 64 75 6c  65 1f 41 6d  65 72 69 63  61 2f 4e 65   edule.America/Ne
0130:   77 5f 59 6f  72 6b 3b 4f  2c 4f 2c 4f  2c 4f 2c 4f   w_York;O,O,O,O,O
0140:   2c 4f 2c 4f  3b 06 73 79  6d 62 6f 6c  11 43 72 79   ,O,O;.symbol.Cry
0150:   70 74 6f 2e  43 52 54 2f  55 53 44 2e  52 52 00 00   pto.CRT/USD.RR..
```

I reproduced the issue in the old version and confirmed that this change fixes the problem.