### PR TITLE
Lazer exporter fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3705,11 +3705,12 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
  "backoff",
+ "base64 0.22.1",
  "bincode 2.0.1",
  "bytemuck",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "3.0.1"
+version = "3.0.2"
 edition = "2024"
 
 [[bin]]
@@ -10,6 +10,7 @@ path = "src/bin/agent.rs"
 [dependencies]
 anyhow = "1.0.81"
 backoff = "0.4.0"
+base64 = "0.22.1"
 ed25519-dalek = "2.1.1"
 serde = { version = "1.0.197", features = ["derive", "rc"] }
 async-trait = "0.1.79"


### PR DESCRIPTION
- Use Lazer pubkey as authorization token for relayer
- Fetch symbol list from history service periodically