### PR TITLE
Allow for optional configured authorization_token for relayer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3721,7 +3721,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-agent"
-version = "3.0.4"
+version = "3.0.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-agent"
-version = "3.0.4"
+version = "3.0.5"
 edition = "2024"
 
 [[bin]]


### PR DESCRIPTION
Similar to pyth-lazer-agent.